### PR TITLE
Fixed bug which prevented winstone jar from being downloaded

### DIFF
--- a/lib/warbler/traits/war.rb
+++ b/lib/warbler/traits/war.rb
@@ -104,11 +104,11 @@ module Warbler
           # Not always covered in tests as these lines may not get
           # executed every time if the jar is cached.
           puts "Downloading #{winstone_type}.jar" #:nocov:
-          mkdir_p File.dirname(t.name)            #:nocov:
+          mkdir_p File.dirname(winstone_jar)      #:nocov:
           require 'open-uri'                      #:nocov:
           maven_repo = ENV["MAVEN_REPO"] || "http://repo2.maven.org/maven2" #:nocov:
           open("#{maven_repo}/#{winstone_path}") do |stream| #:nocov:
-            File.open(t.name, "wb") do |f|  #:nocov:
+            File.open(winstone_jar, "wb") do |f| #:nocov:
               while buf = stream.read(4096) #:nocov:
                 f << buf                    #:nocov:
               end                           #:nocov:


### PR DESCRIPTION
You should be able to see two test failures before accepting the pull request if you delete the cached winstone jar from your ~/.m2 directory.
