### PR TITLE
I have digging into why bundler isn't getting pulled into the package properly under rvm

### DIFF
--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -39,10 +39,19 @@ module Warbler
         lockfile = root.join('Gemfile.lock')
         definition = ::Bundler::Definition.build(gemfile, lockfile, nil)
         groups = definition.groups - config.bundle_without.map {|g| g.to_sym}
-        definition.specs_for(groups).each {|spec| config.gems << spec }
+        definition.specs_for(groups).each { |spec|
+          spec_warning(spec)
+          config.gems << spec
+        }
         config.init_contents << StringIO.new("ENV['BUNDLE_WITHOUT'] = '#{config.bundle_without.join(':')}'\n")
       end
-
+      
+      def spec_warning(spec)
+        if spec && spec.files.empty?
+          $stderr.puts "WARNING:  Gem::Specification for #{spec.name} has no files in it.  This probably means that there is currently an environment problem that we can\'t resolve. Perhaps manually copy the #{ spec.name } gem and spec into the current rvm gemset?"
+        end  
+      end
+      
       def update_archive(jar)
         add_bundler_files(jar) if config.bundler
       end


### PR DESCRIPTION
There is some interesting behavior happening that I don't completely understand. 

The short of it is that the bundler Gem::Specification (Gem.loaded_specs['bundler']) is empty of files and other info in the warbler environment after you require it in bundler.rb WHEN you are running a gemset under rvm.  This is not the case when I run irb under jruby in the same gemset environment.

So I simply added a warning when there are no files being added for a gem.  This way I know long before deployment time that something is fishy.

I would have tracked it down further but setting up the environment over and over was taking too much time.

This may help in the meantime however.
