### PR TITLE
added system property to allow JarMain to not use System.exit in normal flow, this was causing problem when using a service wrapper

### DIFF
--- a/ext/JarMain.java
+++ b/ext/JarMain.java
@@ -128,7 +128,7 @@ public class JarMain implements Runnable {
     public static void main(String[] args) {
         try {
             int exit = new JarMain(args).start();
-            System.exit(exit);
+            if(isSystemExitEnabled()) System.exit(exit);
         } catch (Exception e) {
             Throwable t = e;
             while (t.getCause() != null && t.getCause() != t) {
@@ -144,5 +144,14 @@ public class JarMain implements Runnable {
 
     private static boolean isDebug() {
         return System.getProperty("warbler.debug") != null;
+    }
+
+    /**
+     * if warbler.skip_system_exit system property is defined, we will not
+     * call System.exit in the normal flow. System.exit can cause problems
+     * for wrappers like procrun
+     */
+    private static boolean isSystemExitEnabled(){
+        return System.getProperty("warbler.skip_system_exit") == null; //omission enables System.exit use
     }
 }


### PR DESCRIPTION
Nick,

I was trying to use a warbled project with the Apache commons-daemon service wrapper in windows which is called procrun. 

When the warbled process would exit it was calling System.exit in the normal flow and this was causing an exception for the service wrapper (pipe broken error 109). In searching for the problem, I found that it said any child process should not call System.exit.

So assuming that System.exit is needed in some situations, I added a system property called warbler.skip_system_exit which if defined cause JarMain to not call System.exit in the normal exit flow and this solves the problem for when used with procrun. Thus it could be used with or without System.exit being called depending on whether property is defined.

I did not know how to write a test for this, but I have verified that it solves the problem when I enable the switch.

I also did not build the warbler_jar.jar yet since I had issue getting dev environment setup, so we will need to do that yet for it to take effect.

Feel free to change the property name or whatever you think is best to get this into the JarMain. 

Thanks,

Jeff
