### PR TITLE
Fix for bundling gems with warbler

### DIFF
--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -7,6 +7,7 @@
 
 require 'zip/zip'
 require 'stringio'
+require 'pathname' unless defined?(Pathname)
 
 module Warbler
   # Class that holds the files that will be stored in the jar file.


### PR DESCRIPTION
Hi there,

I've been playing around with Warbler lately and wanted to use the gem bundling feature. It turns out that with the latest ruby 1.8.7 and jruby 1.6.1 the class Pathname is not included by default which causes the following error:

warble aborted!
uninitialized constant Warbler::Jar::Pathname
org/jruby/RubyModule.java:2526:in `const_missing'

This pull request adds this class to jar.rb so that bundling with gems works again.
