### PR TITLE
get bundler_specs without creating new definition or modifying bundler settings.

### DIFF
--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -95,13 +95,9 @@ module Warbler
       private
 
       def bundler_specs
-	original_without = ::Bundler.settings.without
-	::Bundler.settings.without = config.bundle_without
-
-	::Bundler::Definition.build(::Bundler.default_gemfile, ::Bundler.default_lockfile, nil).requested_specs
-      ensure
-	# need to set the settings back, otherwise they get persisted in .bundle/config
-	::Bundler.settings[:without] = original_without.join(':')
+	bundle_without = config.bundle_without.map {|s| s.to_sym}
+	definition = ::Bundler.definition
+        definition.specs_for(definition.groups - bundle_without)
       end
     end
   end

--- a/lib/warbler/version.rb
+++ b/lib/warbler/version.rb
@@ -6,5 +6,5 @@
 #++
 
 module Warbler
-  VERSION = "1.3.1"
+  VERSION = "1.3.2.dev"
 end

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{warbler}
-  s.version = "1.3.1"
+  s.version = "1.3.2.dev"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Nick Sieger"]


### PR DESCRIPTION
Use existing Bundler.definition, Bundler.groups, and Bundler.without to
get bundler_specs without creating new definition or modifying bundler
settings.

Hi Nick,

I meant to submit this a while back. I had come up with this patch to solve the same issue with Warbler not excluding test and development groups as solved by '0bf8599a - Merge pull request #32 from ratnikov/master'. Not sure if its any better or worth changing but I'd figured I'd submit it anyway.

--lenny
