### PR TITLE
Windows show-stopper: File.unlink doesn't work like it does on POSIX systems

### DIFF
--- a/lib/warbler/traits/war.rb
+++ b/lib/warbler/traits/war.rb
@@ -151,7 +151,7 @@ module Warbler
         @empty_jar ||= begin
           t = Tempfile.new(["empty", "jar"])
           path = t.path
-          t.unlink
+          t.close!
           Zip::ZipFile.open(path, Zip::ZipFile::CREATE) do |zipfile|
             zipfile.mkdir("META-INF")
             zipfile.get_output_stream("META-INF/MANIFEST.MF") {|f| f << ::Warbler::Jar::DEFAULT_MANIFEST }


### PR DESCRIPTION
On Windows, File#unlink does not delete the file like it does on POSIX, so ZipFile fails to create the file, trying to validate the (empty) tempfile. File.close! closes and then unlinks it, which is fine since we aren't writing to it directly anyway.
On a more abstract level, I'm not sure why we are creating a Tempfile to begin with. Couldn't we just go ahead and write to the file we're trying to create, or at least to a "filename.temp.jar" in the same directory instead of in the temp directory?
