### PR TITLE
Added check for Rails threadsafe! mode in config/environment.rb

### DIFF
--- a/lib/warbler/traits/rails.rb
+++ b/lib/warbler/traits/rails.rb
@@ -45,7 +45,8 @@ module Warbler
         config.init_contents << "#{config.warbler_templates}/rails.erb"
         begin
           rails_env = config.webxml.rails.env
-          unless IO.readlines("config/environments/#{rails_env}.rb").grep(/^\s*config\.threadsafe!/).empty?
+          unless IO.readlines("config/environments/#{rails_env}.rb").grep(/^\s*config\.threadsafe!/).empty? &&
+                 IO.readlines("config/environment.rb").grep(/^\s*config\.threadsafe!/).empty?
             config.webxml.jruby.min.runtimes = 1 unless Integer === config.webxml.jruby.min.runtimes
             config.webxml.jruby.max.runtimes = 1 unless Integer === config.webxml.jruby.max.runtimes
           end


### PR DESCRIPTION
Other frameworks, such as Trinidad and TorqueBox, pick this setting up in the environment.rb.  
