### PR TITLE
Introduce a QueuedThreadPool to try to utilise multiple cores

### DIFF
--- a/ext/jetty/src/main/java/JettyWarMain.java
+++ b/ext/jetty/src/main/java/JettyWarMain.java
@@ -1,7 +1,9 @@
 
+import org.eclipse.jetty.server.AbstractConnector;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 import java.io.File;
@@ -27,8 +29,9 @@ public class JettyWarMain {
         webapp.setDefaultsDescriptor(webdefaultPath());
 
         Server server = new Server();
-        Connector connector = new SelectChannelConnector();
+        AbstractConnector connector = new SelectChannelConnector();
         connector.setPort(Integer.getInteger("jetty.port",8080).intValue());
+        connector.setThreadPool(new QueuedThreadPool(Integer.getInteger("jetty.threadpool.size",Runtime.getRuntime().availableProcessors()+1)));
         server.setConnectors(new Connector[]{connector});
         server.setHandler(webapp);
         server.start();


### PR DESCRIPTION
I was running https://github.com/garethr/jruby-embedded-jetty and noted that only one core seems to get used. I'm suggesting this change in the hope that it will use all of the available cores where possible.

It might be that the application is purely IO-bound and that's why I only see a single core running hot, but I don't know jetty well enough to say for sure.
