### PR TITLE
Ensure that compiled war file is compiled with the right Ruby version

### DIFF
--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -45,7 +45,13 @@ module Warbler
 
     def run_javac(config, compiled_ruby_files)
       # Need to use the version of JRuby in the application to compile it
-      %x{java -classpath #{config.java_libs.join(File::PATH_SEPARATOR)} org.jruby.Main -S jrubyc \"#{compiled_ruby_files.join('" "')}\"}
+      `java -classpath #{config.java_libs.join(File::PATH_SEPARATOR)} org.jruby.Main #{ruby_version(config)} -S jrubyc "#{compiled_ruby_files.join('" "')}"`
+    end
+
+    def ruby_version(config)
+      # Using Ruby version from the config or falling back to current Ruby version
+      ruby_version = config.webxml && config.webxml.context_params['jruby.compat.version'] || RUBY_VERSION
+      "--#{ruby_version.to_f}"
     end
 
     def replace_compiled_ruby_files(config, compiled_ruby_files)

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -762,6 +762,30 @@ describe Warbler::Jar do
       jar.apply(config)
       jar.contents('META-INF/init.rb').should =~ /<dummy\/>/
     end
+
+    context 'jruby compiler ruby version' do
+      it 'set to ruby version defined in config.webxml.jruby.compat.version 1.9' do
+        use_config do |config|
+          config.webxml.jruby.compat.version = "1.9"
+        end
+        jar.should_receive(:'`').with(/\s--1.9\s/)
+        jar.compile(config)
+      end
+      it 'set to ruby version defined in config.webxml.jruby.compat.version 1.8.7' do
+        use_config do |config|
+          config.webxml.jruby.compat.version = "1.8.7"
+        end
+        jar.should_receive(:'`').with(/\s--1.8\s/)
+        jar.compile(config)
+      end
+      context 'when config.webxml.jruby.compat.version is not defined' do
+        it "set to ruby version defined by RUBY_VERSION (#{RUBY_VERSION})" do
+          jar.should_receive(:'`').with(/\s--#{RUBY_VERSION.to_f}\s/)
+          jar.compile(config)
+        end
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
We currently compile and deploy war files using jruby-1.6.7 in 1.9 mode and found that compile option in warbler was causing compilation to occur in 1.8 mode regardless of flag set in jruby or in warble.rb config.

This might only occur when invoking jruby using 'java -jar jruby-complete-x.x.x.jar' rather than from the exploded jruby distribution (which uses a wrapper script to invoke jruby and jrubyc).
