### PR TITLE
Support URL unsafe path characters when booting a war

### DIFF
--- a/ext/WarMain.java
+++ b/ext/WarMain.java
@@ -58,14 +58,14 @@ public class WarMain implements Runnable {
     public static final String WEBSERVER_JAR = "/WEB-INF/webserver.jar";
 
     private String[] args;
-    private String path, warfile;
+    private String warfile;
     private boolean debug;
     private File webroot;
 
     public WarMain(String[] args) throws Exception {
         this.args = args;
         URL mainClass = getClass().getResource(MAIN);
-        this.path = mainClass.toURI().getSchemeSpecificPart();
+        String path = mainClass.toURI().getSchemeSpecificPart();
         this.warfile = this.path.replace("!" + MAIN, "").replace("file:", "");
         this.debug = isDebug();
         this.webroot = File.createTempFile("warbler", "webroot");
@@ -77,7 +77,7 @@ public class WarMain implements Runnable {
     }
 
     private URL extractWebserver() throws Exception {
-        InputStream jarStream = new URL("jar:" + path.replace(MAIN, WEBSERVER_JAR)).openStream();
+        InputStream jarStream = getClass().getResourceAsStream(WEBSERVER_JAR);
         File jarFile = File.createTempFile("webserver", ".jar");
         jarFile.deleteOnExit();
         FileOutputStream outStream = new FileOutputStream(jarFile);


### PR DESCRIPTION
Avoid converting war paths to URLs so that we don't have to deal with
special characters.

Eg: some_application##123.jar

---

This is a first step in trying to figure out why jars with # characters in their name don't work properly in jruby. Specifically, we're trying to also use Tomcat's Parallel Deployments, and are seeing the same issues found in http://stackoverflow.com/questions/8822593/double-pound-in-path-name-doesnt-work-with-jruby-require and http://jira.codehaus.org/browse/JRUBY-6339.

Without this diff, if you warble up an executable war with a '#' in it's name, when you attempt to run it (via java -jar) you get a "no !/ in spec" error. It is being thrown in warbler by this line:

```
new URL("jar:" + path.replace(MAIN, WEBSERVER_JAR))
```

I've switched it to not try and convert things to a url, just to pull a stream out. Instead it just goes straight to a stream.

If you don't see any large objections to this, I'd be happy to write a test for it, but I could use some guidance on where/how you'd want this tested.

And of note, even with this, things still dont' work properly for wars with a # in their name. This is just the first step. Up next is:

```
> java -jar packages/simple\#1.war
webroot directory is /var/folders/UQ/UQIKbVuOF8ucWUlgQbVgak+++TM/-Tmp-/warbler405623839606535107webroot/simple#1.war
webserver.jar extracted to /var/folders/UQ/UQIKbVuOF8ucWUlgQbVgak+++TM/-Tmp-/webserver2343786333088129610.jar
invoking webserver with: [--warfile=/Volumes/Encrypted/workspace/deal-catalog-service/packages/simple#1.war, --webroot=/var/folders/UQ/UQIKbVuOF8ucWUlgQbVgak+++TM/-Tmp-/warbler405623839606535107webroot/simple#1.war, --directoryListings=false]
May 25, 2012 12:30:08 AM winstone.Logger logInternal
INFO: Beginning extraction from war file
May 25, 2012 12:30:10 AM winstone.Logger logInternal
WARNING: No webapp classes folder found - /private/var/folders/UQ/UQIKbVuOF8ucWUlgQbVgak+++TM/-Tmp-/warbler405623839606535107webroot/simple#1.war/WEB-INF/classes
May 25, 2012 12:30:10 AM winstone.Logger logInternal
WARNING: Error instantiating listener class: org.jruby.rack.rails.RailsServletContextListener
May 25, 2012 12:30:10 AM winstone.Logger logInternal
SEVERE: Failed to load class: org.jruby.rack.RackFilter
java.lang.ClassNotFoundException: org.jruby.rack.RackFilter
  at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
  at java.security.AccessController.doPrivileged(Native Method)
  at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
  at winstone.classLoader.WebappClassLoader.loadClass(WebappClassLoader.java:83)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
  at java.lang.Class.forName0(Native Method)
  at java.lang.Class.forName(Class.java:247)
  at winstone.FilterConfiguration.getFilter(FilterConfiguration.java:125)
  at winstone.WebAppConfiguration.<init>(WebAppConfiguration.java:893)
  at winstone.HostConfiguration.initWebApp(HostConfiguration.java:129)
  at winstone.HostConfiguration.<init>(HostConfiguration.java:71)
  at winstone.HostGroup.initHost(HostGroup.java:87)
  at winstone.HostGroup.<init>(HostGroup.java:47)
  at winstone.Launcher.<init>(Launcher.java:177)
  at winstone.Launcher.main(Launcher.java:384)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
  at java.lang.reflect.Method.invoke(Method.java:597)
  at WarMain.launchWebserver(WarMain.java:144)
  at WarMain.start(WarMain.java:164)
  at WarMain.main(WarMain.java:190)
May 25, 2012 12:30:10 AM winstone.Logger logInternal
INFO: HTTP Listener started: port=8080
May 25, 2012 12:30:10 AM winstone.Logger logInternal
INFO: AJP13 Listener started: port=8009
May 25, 2012 12:30:10 AM winstone.Logger logInternal
INFO: Winstone Servlet Engine v0.9.10 running: controlPort=disabled
```
