### PR TITLE
Reset ENV['GEM_HOME'], limit search to within .jar

### DIFF
--- a/lib/warbler/config.rb
+++ b/lib/warbler/config.rb
@@ -115,6 +115,12 @@ module Warbler
     # If the filename ends in .erb the file will be expanded the same way web.xml.erb is; see below.
     attr_accessor :init_contents
 
+    # Ignore GEM_HOME environment variable at runtime. When false, gems in
+    # GEM_HOME will be loaded in preference to those packaged within the jar
+    # file. When true, only gems packaged in the jar file will be loaded.
+    # Defaults to false
+    attr_accessor :ignore_gem_home
+
     # Extra configuration for web.xml. Controls how the dynamically-generated web.xml
     # file is generated.
     #
@@ -172,6 +178,7 @@ module Warbler
       @webinf_files      = FileList[]
       @init_filename     = 'META-INF/init.rb'
       @init_contents     = ["#{@warbler_templates}/config.erb"]
+      @ignore_gem_home   = false
 
       before_configure
       yield self if block_given?

--- a/lib/warbler/templates/jar.erb
+++ b/lib/warbler/templates/jar.erb
@@ -1,7 +1,8 @@
+<% assignment_operator = config.ignore_gem_home ? "=" : "||=" %>
 <% if config.relative_gem_path.empty? %>
-ENV['GEM_HOME'] = File.expand_path('../..', __FILE__)
+ENV['GEM_HOME'] <%= assignment_operator %> File.expand_path('../..', __FILE__)
 <% else %>
-ENV['GEM_HOME'] ||= File.expand_path('../../<%= config.relative_gem_path %>', __FILE__)
+ENV['GEM_HOME'] <%= assignment_operator %> File.expand_path('../../<%= config.relative_gem_path %>', __FILE__)
 <% end %>
 <% if config.bundler && config.bundler[:gemfile_path] %>
 ENV['BUNDLE_GEMFILE'] = File.expand_path('../../<%= config.bundler[:gemfile_path] %>', __FILE__)

--- a/spec/warbler/config_spec.rb
+++ b/spec/warbler/config_spec.rb
@@ -19,6 +19,7 @@ describe Warbler::Config do
       config = Warbler::Config.new
       config.includes.should be_empty
       config.jar_name.size.should > 0
+      config.ignore_gem_home.should be_false
     end
   end
 
@@ -38,6 +39,7 @@ describe Warbler::Config do
       config.webxml.should be_kind_of(OpenStruct)
       config.pathmaps.should be_kind_of(OpenStruct)
       config.pathmaps.public_html.should == ["%{public/,}p"]
+      config.ignore_gem_home.should be_false
     end
 
     it "should allow configuration through an initializer block" do

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -209,6 +209,24 @@ describe Warbler::Jar do
         contents.split("\n").grep(/load.*sample_jar\/bin\/sample_jar/).should_not be_empty
       end
     end
+
+    context "when configured to respect GEM_HOME" do
+      it "uses current value of GEM_HOME" do
+        config.ignore_gem_home = false
+        jar.apply(config)
+        contents = jar.contents('META-INF/init.rb')
+        contents.split("\n").grep(/GEM_HOME/).first.should include("ENV['GEM_HOME'] ||=")
+      end
+    end
+
+    context "when configured to ignore GEM_HOME" do
+      it "ignores current value of GEM_HOME" do
+        config.ignore_gem_home = true
+        jar.apply(config)
+        contents = jar.contents('META-INF/init.rb')
+        contents.split("\n").grep(/GEM_HOME/).first.should include("ENV['GEM_HOME'] =")
+      end
+    end
   end
 
   context "in a war project" do


### PR DESCRIPTION
When packaging up gems in a .jar, make GEM_HOME point to those packaged gems.

This is possibly related to (at least part of) #103
