### PR TITLE
Try loading gemspec first, fall back to YAML

### DIFF
--- a/lib/warbler/traits/gemspec.rb
+++ b/lib/warbler/traits/gemspec.rb
@@ -19,8 +19,12 @@ module Warbler
 
       def before_configure
         @spec_file = Dir['*.gemspec'].first
-        require 'yaml'
-        @spec = File.open(@spec_file) {|f| Gem::Specification.from_yaml(f) } rescue Gem::Specification.load(@spec_file)
+        begin
+          @spec = Gem::Specification.load(@spec_file)
+        rescue
+          require 'yaml'
+          @spec = File.open(@spec_file) {|f| Gem::Specification.from_yaml(f) }
+        end
         @spec.runtime_dependencies.each {|g| config.gems << g }
         config.dirs = []
         config.compiled_ruby_files = @spec.files.select {|f| f =~ /\.rb$/}


### PR DESCRIPTION
For some reason, warbler was failing catch the YAML load error when packaging with a Ruby gemspec. This flips the order. I'm not sure this is the final solution, but a conversation starter, perhaps.
