### PR TITLE
Allow RAILS_ENV override by servlet container

### DIFF
--- a/lib/warbler/templates/rails.erb
+++ b/lib/warbler/templates/rails.erb
@@ -1,1 +1,1 @@
-ENV['RAILS_ENV'] = '<%= config.webxml.rails.env %>'
+ENV['RAILS_ENV'] ||= '<%= config.webxml.rails.env %>'


### PR DESCRIPTION
This way I wouldn't have to generate a different WAR for each
 environment (production, staging, etc). I could set RAILS_ENV on
 GlassFish, Tomcat, etc.

This is specially useful after a WAR has been validated on staging
 and you want to copy it to production servers.
