### PR TITLE
warble pluginize does not work on rails 3.x

### DIFF
--- a/lib/warbler/task.rb
+++ b/lib/warbler/task.rb
@@ -162,13 +162,13 @@ module Warbler
 
     def define_pluginize_task
       task "pluginize" do
-        if !Dir["vendor/plugins/warbler*"].empty? && ENV["FORCE"].nil?
-          puts "I found an old nest in vendor/plugins; please trash it so I can make a new one"
-          puts "(directory vendor/plugins/warbler* exists)"
+        if !Dir["lib/tasks/warbler*"].empty? && ENV["FORCE"].nil?
+          puts "I found an old nest in lib/tasks; please trash it so I can make a new one"
+          puts "(directory lib/tasks/warbler* exists)"
         else
-          rm_rf FileList["vendor/plugins/warbler*"], :verbose => false
-          mkdir_p "vendor/plugins/warbler/tasks"
-          File.open("vendor/plugins/warbler/tasks/warbler.rake", "w") do |f|
+          rm_rf FileList["lib/tasks/warbler*"], :verbose => false
+          mkdir_p "lib/tasks/warbler"
+          File.open("lib/tasks/warbler/warbler.rake", "w") do |f|
             f.puts "require 'warbler'"
             f.puts "Warbler::Task.new"
           end

--- a/spec/warbler/application_spec.rb
+++ b/spec/warbler/application_spec.rb
@@ -26,7 +26,7 @@ describe Warbler::Application do
     Warbler.application = nil
     Warbler.framework_detection = @detection
     @argv.reverse.each {|a| ARGV.unshift a}
-    rm_rf FileList['vendor/plugins/warbler']
+    rm_rf FileList['lib/tasks/warbler']
   end
 
   it "should be able to list its tasks" do
@@ -67,17 +67,17 @@ describe Warbler::Application do
     end
   end
 
-  it "should refuse to pluginize if the vendor/plugins/warbler directory exists" do
-    mkdir_p "vendor/plugins/warbler"
+  it "should refuse to pluginize if the lib/tasks/warbler directory exists" do
+    mkdir_p "lib/tasks/warbler"
     ARGV.unshift "pluginize"
     silence { Warbler::Application.new.run }
-    File.exist?("vendor/plugins/warbler/tasks/warbler.rake").should_not be_true
+    File.exist?("lib/tasks/warbler/warbler.rake").should_not be_true
   end
 
   it "should define a pluginize task for adding the tasks to a Rails application" do
     ARGV.unshift "pluginize"
     silence { Warbler::Application.new.run }
-    File.exist?("vendor/plugins/warbler/tasks/warbler.rake").should be_true
+    File.exist?("lib/tasks/warbler/warbler.rake").should be_true
   end
 
   it "should provide a means to load the project Rakefile" do


### PR DESCRIPTION
Since rails 2.3-style plugins are deprecated in rails 3.x (and will be removed in rails 4.0), running `warble pluginize` creates the rake task but it does not work (it's not loaded by rails). This is the result:

```
~/Code/github/test_project% be warble pluginize
mkdir -p vendor/plugins/warbler/tasks
~/Code/github/test_project% rake -T
DEPRECATION WARNING: You have Rails 2.3-style plugins in vendor/plugins! Support for these plugins will be removed in Rails 4.0. Move them out and bundle them in your Gemfile, or fold them in to your app as lib/myplugin/* and config/initializers/myplugin.rb. See the release notes for more on this: http://weblog.rubyonrails.org/2012/1/4/rails-3-2-0-rc2-has-been-released. (called from <top (required)> at /Users/patricio/Code/github/test_project/Rakefile:7)
rake about              # List versions of all Rails frameworks and the environment
rake assets:clean       # Remove compiled assets
rake assets:precompile  # Compile all the assets named in config.assets.precompile
rake db:create          # Create the database from config/database.yml for the current Rails.env (use db:create:all to create all dbs in the config)
rake db:drop            # Drops the database for the current Rails.env (use db:drop:all to drop all databases)
rake db:fixtures:load   # Load fixtures into the current environment's database.
rake db:migrate         # Migrate the database (options: VERSION=x, VERBOSE=false).
rake db:migrate:status  # Display status of migrations
rake db:rollback        # Rolls the schema back to the previous version (specify steps w/ STEP=n).
rake db:schema:dump     # Create a db/schema.rb file that can be portably used against any DB supported by AR
rake db:schema:load     # Load a schema.rb file into the database
rake db:seed            # Load the seed data from db/seeds.rb
rake db:setup           # Create the database, load the schema, and initialize with the seed data (use db:reset to also drop the db first)
rake db:structure:dump  # Dump the database structure to db/structure.sql. Specify another file with DB_STRUCTURE=db/my_structure.sql
rake db:version         # Retrieves the current schema version number
rake doc:app            # Generate docs for the app -- also available doc:rails, doc:guides, doc:plugins (options: TEMPLATE=/rdoc-template.rb, TITLE="Custom Title")
rake log:clear          # Truncates all *.log files in log/ to zero bytes
rake middleware         # Prints out your Rack middleware stack
rake notes              # Enumerate all annotations (use notes:optimize, :fixme, :todo for focus)
rake notes:custom       # Enumerate a custom annotation, specify with ANNOTATION=CUSTOM
rake rails:template     # Applies the template supplied by LOCATION=(/path/to/template) or URL
rake rails:update       # Update configs and some other initially generated files (or use just update:configs, update:scripts, or update:application_controller)
rake routes             # Print out all defined routes in match order, with names.
rake secret             # Generate a cryptographically secure secret key (this is typically used to generate a secret for cookie sessions).
rake stats              # Report code statistics (KLOCs, etc) from the application
rake test               # Runs test:units, test:functionals, test:integration together (also available: test:benchmark, test:profile, test:plugins)
rake test:recent        # Run tests for {:recent=>"test:prepare"} / Test recent changes
rake test:single        # Run tests for {:single=>"test:prepare"}
rake test:uncommitted   # Run tests for {:uncommitted=>"test:prepare"} / Test changes since last checkin (only Subversion and Git)
rake time:zones:all     # Displays all time zones, also available: time:zones:us, time:zones:local -- filter with OFFSET parameter, e.g., OFFSET=-6
rake tmp:clear          # Clear session, cache, and socket files from tmp/ (narrow w/ tmp:sessions:clear, tmp:cache:clear, tmp:sockets:clear)
rake tmp:create         # Creates tmp directories for sessions, cache, sockets, and pids
```

This pull requests moves the generated rake task from `vendor/plugins/warbler/tasks/warbler.rake` to `lib/tasks/warbler/warbler.rake`, where it is intended to be.

Thanks!
