### PR TITLE
Fix self executable jar/wars when the filename contains '#' symbols

### DIFF
--- a/ext/JarMain.java
+++ b/ext/JarMain.java
@@ -58,7 +58,7 @@ public class JarMain implements Runnable {
     }
 
     private URL extractJar(String jarpath) throws Exception {
-        InputStream jarStream = new URI("jar", path.replace(MAIN, jarpath), "").toURL().openStream();
+        InputStream jarStream = new URI("jar", path.replace(MAIN, jarpath), null).toURL().openStream();
         String jarname = jarpath.substring(jarpath.lastIndexOf("/") + 1, jarpath.lastIndexOf("."));
         File jarFile = new File(extractRoot, jarname + ".jar");
         jarFile.deleteOnExit();

--- a/ext/WarMain.java
+++ b/ext/WarMain.java
@@ -78,7 +78,7 @@ public class WarMain implements Runnable {
     }
 
     private URL extractWebserver() throws Exception {
-        InputStream jarStream = new URI("jar", path.replace(MAIN, WEBSERVER_JAR), "").toURL().openStream();
+        InputStream jarStream = new URI("jar", path.replace(MAIN, WEBSERVER_JAR), null).toURL().openStream();
         File jarFile = File.createTempFile("webserver", ".jar");
         jarFile.deleteOnExit();
         FileOutputStream outStream = new FileOutputStream(jarFile);


### PR DESCRIPTION
If you create an executable war file with a filename like `app##01.war` and then try to execute it (`java -jar "app##01.war"`) it will fail with:

`error: java.net.MalformedURLException: no !/ in spec`

The attached code should fix this issue.

I didn't add tests because I didn't see any existing tests that actually executed the jar/war files, and I couldn't think of any other way to test this issue. So I don't know if you have any other ideas on testing this, or if adding a test that actually attempts to execute the jar/war is okay.

This is semi-related to [JRUBY-6339](http://jira.codehaus.org/browse/JRUBY-6339) and the [associated pull request](https://github.com/jruby/jruby/pull/388). This patch to Warbler isn't strictly necessary to achieve compatibility with Tomcat 7's parallel deployment features (since the WAR doesn't need to be executable in that case), but I stumbled upon the issue while testing. Also note that the [JRuby pull request](https://github.com/jruby/jruby/pull/388) must also be applied (and the associated jruby-jars updated) for the executable WAR to completely work, this just addresses a related issue that prevented the WAR file from initially loading at all.
