### PR TITLE
Change bundle_without to include assets group 

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -124,8 +124,8 @@ in the project will be included in the archive.
 Applications that use Bundler[http://gembundler.com/], detected via
 presence of a +Gemfile+, will have the gems packaged up into the
 archive along with the Gemfile. The Bundler groups named
-+:development+ and +:test+ will be excluded by default, unless you
-specify with +config.bundle_without+ in +config/warble.rb+.
++:development+ +:test+ and +:assets+ will be excluded by default, unless
+you specify with +config.bundle_without+ in +config/warble.rb+.
 
 Warbler supports Bundler for gems and git repositories, but not for
 plain path components. Warbler will warn when a +:path+ component is

--- a/lib/warbler/config.rb
+++ b/lib/warbler/config.rb
@@ -96,7 +96,7 @@ module Warbler
     attr_accessor :bundler
 
     # An array of Bundler groups to avoid including in the war file.
-    # Defaults to ["development", "test"].
+    # Defaults to ["development", "test", "assets"].
     attr_accessor :bundle_without
 
     # Path to the pre-bundled gem directory inside the war file. Default is '/WEB-INF/gems'.

--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -23,7 +23,7 @@ module Warbler
 
       def before_configure
         config.bundler = true
-        config.bundle_without = ["development", "test"]
+        config.bundle_without = ["development", "test", "assets"]
       end
 
       def after_configure

--- a/spec/warbler/bundler_spec.rb
+++ b/spec/warbler/bundler_spec.rb
@@ -96,7 +96,7 @@ describe Warbler::Jar, "with Bundler" do
       jar.add_init_file(config)
       contents = jar.contents('META-INF/init.rb')
       contents.should =~ /ENV\['BUNDLE_WITHOUT'\]/
-      contents.should =~ /'development:test'/
+      contents.should =~ /'development:test:assets'/
     end
 
     it "adds BUNDLE_GEMFILE to init.rb" do

--- a/warble.rb
+++ b/warble.rb
@@ -41,7 +41,7 @@ Warbler::Config.new do |config|
   # config.bundler = false
 
   # An array of Bundler groups to avoid including in the war file.
-  # Defaults to ["development", "test"].
+  # Defaults to ["development", "test", "assets"].
   # config.bundle_without = []
 
   # Other gems to be included. If you don't use Bundler or a gemspec


### PR DESCRIPTION
Rails defaults to precompile assets which excludes the assets group
in production. We should mimic rails defaults.
