### PR TITLE
Resolving issue when an alternate BUNDLE_PATH is used

### DIFF
--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -41,8 +41,16 @@ module Warbler
           # bundler gemspec from bundler/source.rb
           if spec.name == "bundler"
             full_gem_path = Pathname.new(spec.full_gem_path)
-            tries = 2
-            (full_gem_path = full_gem_path.dirname; tries -= 1) while tries > 0 && !full_gem_path.join('bundler.gemspec').exist?
+
+            while !full_gem_path.join('bundler.gemspec').exist?
+              full_gem_path = full_gem_path.dirname
+              # if at top of the path, meaning we cannot find bundler.gemspec, abort.
+              if full_gem_path.to_s=~/^[\.\/]$/
+                $stderr.puts("warning: Unable to detect bundler spec under '#{spec.full_gem_path}'' and is sub-dirs")
+                exit
+              end
+            end
+
             spec.loaded_from = full_gem_path.join('bundler.gemspec').to_s
             # RubyGems 1.8.x: @full_gem_path is cached, so we have to set it
             def spec.full_gem_path=(p); @full_gem_path = p; end


### PR DESCRIPTION
Issue description:

If BUNDLE_PATH in .bundle/config is set to some other directory, for example  

```
BUNDLE_PATH: vendor/foobar
```

or if bundle install was previous executed with --path parameter

```
bundle install --path vendor/foobar
```

Warbler will not able to detect the bundler's gemspec location correctly (from the bundler's load_from attribute).  As the result, a corrupted bundle gem will be included into the war file and we will see a load error when attempting to run this war file inside a servlet container.

Analysis:

The existing code seems to have some logic that tries to detect the location of the bundler.gemspec based on the bundler's load_from attribute.  However, the implementation quits after looking up parent folder two times and silently continue without raising any error.

Proposed Change:

Instead of just lookup parent folders for 2 levels, the fix keep searching for the bundler gemspec until it hits the root dir.  If bundler gemspec cannot be found, it will raise an error message and exit the build process.
