### PR TITLE
Comment out config.dirs to match default

### DIFF
--- a/warble.rb
+++ b/warble.rb
@@ -11,7 +11,7 @@ Warbler::Config.new do |config|
   # config.features = %w(gemjar)
 
   # Application directories to be included in the webapp.
-  config.dirs = %w(app config db lib log vendor tmp)
+  # config.dirs = %w(app config db lib log vendor tmp)
 
   # Additional files/directories to include, above those in config.dirs
   # config.includes = FileList["db"]


### PR DESCRIPTION
This ensures that e.g. `script/rails` continues to work after a user creates `config/warble.rb`, i.e. no surprises.
