### PR TITLE
Stop copying all the files to war files. Proposed fix for issue 156.

### DIFF
--- a/lib/warbler/traits/gemspec.rb
+++ b/lib/warbler/traits/gemspec.rb
@@ -33,9 +33,16 @@ module Warbler
       end
 
       def update_archive(jar)
-        (Dir['**/*'] - config.compiled_ruby_files).each do |f|
-          jar.files[apply_pathmaps(config, f, :application)] = f
+        @spec.files.each do |f|
+          unless File.exist?(f)
+            warn "update your gemspec; skipping missing file #{f}"
+            next
+          end
+          file_key = jar.apply_pathmaps(config, f, :application)
+          next if jar.files[file_key]
+          jar.files[file_key] = f
         end
+        
         config.compiled_ruby_files.each do |f|
           f = f.sub(/\.rb$/, '.class')
           next unless File.exist?(f)


### PR DESCRIPTION
When running warble command includes and excludes are ignored.
I think it might be because of a change that was done previously.
https://github.com/jruby/warbler/commit/79f830fcd335fc17dabab4d6f5821cb8c40f1ade#L2L35

With this change applied, I can now get only the files inside the war file that I want.
