### PR TITLE
WAR project also should respect `override_gem_home` option

### DIFF
--- a/lib/warbler/templates/war.erb
+++ b/lib/warbler/templates/war.erb
@@ -1,4 +1,4 @@
-ENV['GEM_HOME'] ||= $servlet_context.getRealPath('<%= config.gem_path %>')
+ENV['GEM_HOME'] <%= config.override_gem_home ? '=' : '||=' %> $servlet_context.getRealPath('<%= config.gem_path %>')
 <% if config.bundler && config.bundler[:gemfile_path] %>
 ENV['BUNDLE_GEMFILE'] ||= $servlet_context.getRealPath('/<%= config.bundler[:gemfile_path] %>')
 <% end %>

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -58,14 +58,14 @@ describe Warbler::Jar do
     it "does not override ENV['GEM_HOME'] by default" do
       jar.add_init_file(config)
       contents = jar.contents('META-INF/init.rb')
-      contents.should =~ %r{ENV['GEM_HOME'] ||=}
+      contents.should include("ENV['GEM_HOME'] ||=")
     end
 
     it "overrides ENV['GEM_HOME'] when override_gem_home is set" do
       config.override_gem_home = true
       jar.add_init_file(config)
       contents = jar.contents('META-INF/init.rb')
-      contents.should =~ /ENV\['GEM_HOME'\] =/
+      contents.should include("ENV['GEM_HOME'] =")
     end
 
     it "adds a main.rb" do
@@ -262,8 +262,15 @@ describe Warbler::Jar do
     it "adds ENV['GEM_HOME'] to init.rb" do
       jar.add_init_file(config)
       contents = jar.contents('META-INF/init.rb')
-      contents.should =~ /ENV\['GEM_HOME'\]/
+      contents.should include("ENV['GEM_HOME'] ||=")
       contents.should =~ /WEB-INF\/gems/
+    end
+
+    it "overrides ENV['GEM_HOME'] when override_gem_home is set" do
+      config.override_gem_home = true
+      jar.add_init_file(config)
+      contents = jar.contents('META-INF/init.rb')
+      contents.should include("ENV['GEM_HOME'] =")
     end
 
     it "does not include log files by default" do


### PR DESCRIPTION
A few months ago, `override_gem_home` option was introduced (#112), however it hasn't been applied to WAR projects.

The commit also fixes an invalid spec (always-true regexp) for the option.
