### PR TITLE
allow specifying executable to run including other gems executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ warbler.iml
 warbler.iws
 warbler.ipr
 warbler-*.gem
+log

--- a/lib/warbler.rb
+++ b/lib/warbler.rb
@@ -10,7 +10,7 @@
 module Warbler
   WARBLER_HOME = File.expand_path(File.dirname(__FILE__) + '/..') unless defined?(WARBLER_HOME)
   WARBLER_JAR = "#{WARBLER_HOME}/lib/warbler_jar.jar" unless defined?(WARBLER_JAR)
-  
+
   class << self
     # An instance of Warbler::Application used by the +warble+ command.
     attr_accessor :application
@@ -30,6 +30,7 @@ module Warbler
 end
 
 require 'warbler/version'
+require 'warbler/executable_helper'
 require 'warbler/rake_helper'
 require 'warbler/pathmap_helper'
 require 'warbler/task'

--- a/lib/warbler/config.rb
+++ b/lib/warbler/config.rb
@@ -78,6 +78,12 @@ module Warbler
     # entries in this structure).
     attr_accessor :pathmaps
 
+    # Executable of the jar
+    attr_accessor :executable
+
+    # parameters to pass to the executable
+    attr_accessor :executable_params
+
     # Name of jar or war file (without the extension), defaults to the
     # directory name containing the application.
     attr_accessor :jar_name

--- a/lib/warbler/executable_helper.rb
+++ b/lib/warbler/executable_helper.rb
@@ -1,0 +1,25 @@
+#--
+# Copyright (c) 2013 Michal Papis.
+# This source code is available under the MIT license.
+# See the file LICENSE.txt for details.
+#++
+
+module Warbler
+  module ExecutableHelper
+    def update_archive_add_executable(jar)
+      case executable
+      when Array
+        gem_name, executable_path = executable
+        gem_with_version = config.gems.full_name_for(gem_name, config.gem_dependencies)
+        bin_path = apply_pathmaps(config, File.join(gem_with_version, executable_path), :gems)
+      else
+        bin_path = apply_pathmaps(config, executable, :application)
+      end
+      add_main_rb(jar, bin_path, config.executable_params)
+    end
+
+    def executable
+      config.executable ||= default_executable
+    end
+  end
+end

--- a/lib/warbler/gems.rb
+++ b/lib/warbler/gems.rb
@@ -21,17 +21,56 @@ module Warbler
     end
 
     def <<(gem)
+      @specs = nil
       self[gem] ||= ANY_VERSION
     end
 
     def +(other)
+      @specs = nil
       other.each {|g| self[g] ||= ANY_VERSION }
       self
     end
 
     def -(other)
+      @specs = nil
       other.each {|g| self.delete(g)}
       self
     end
+
+    def full_name_for(name, gem_dependencies)
+      spec = specs(gem_dependencies).detect{ |spec| spec.name == name }
+      spec.nil? ? name : spec.full_name
+    end
+
+    def specs(gem_dependencies)
+      @specs ||= map{|gem, version| find_single_gem_files(gem_dependencies, gem, version) }.flatten.compact
+    end
+
+  private
+
+    # Add a single gem to WEB-INF/gems
+    def find_single_gem_files(gem_dependencies, gem_pattern, version = nil)
+      case gem_pattern
+      when Gem::Specification
+        return gem_pattern
+      when Gem::Dependency
+        gem = gem_pattern
+      else
+        gem = Gem::Dependency.new(gem_pattern, Gem::Requirement.create(version))
+      end
+      # skip development dependencies
+      return nil if gem.respond_to?(:type) and gem.type != :runtime
+
+      # Deal with deprecated Gem.source_index and #search
+      matched = gem.respond_to?(:to_spec) ? [gem.to_spec] : Gem.source_index.search(gem)
+      fail "gem '#{gem}' not installed" if matched.empty?
+      spec = matched.last
+      if gem_dependencies
+        [spec] + spec.dependencies.map{|gem| find_single_gem_files(gem_dependencies, gem) }
+      else
+        spec
+      end
+    end
+
   end
 end

--- a/lib/warbler/traits.rb
+++ b/lib/warbler/traits.rb
@@ -80,8 +80,11 @@ module Warbler
       config.init_contents << StringIO.new("$LOAD_PATH.unshift __FILE__.sub(/!.*/, '!/#{path}')\n")
     end
 
-    def add_main_rb(jar, bin_path)
-      jar.files['META-INF/main.rb'] = StringIO.new("load '#{bin_path}'")
+    def add_main_rb(jar, bin_path, params = nil)
+      binary = ""
+      binary << "ARGV.unshift('#{params}')\n" if params
+      binary << "load '#{bin_path}'"
+      jar.files['META-INF/main.rb'] = StringIO.new(binary)
     end
 
     def update_gem_path(default_gem_path)

--- a/lib/warbler/traits/gemspec.rb
+++ b/lib/warbler/traits/gemspec.rb
@@ -12,6 +12,7 @@ module Warbler
     class Gemspec
       include Trait
       include PathmapHelper
+      include ExecutableHelper
 
       def self.detect?
         !Dir['*.gemspec'].empty?
@@ -42,14 +43,14 @@ module Warbler
           next if jar.files[file_key]
           jar.files[file_key] = f
         end
-        
+
         config.compiled_ruby_files.each do |f|
           f = f.sub(/\.rb$/, '.class')
           next unless File.exist?(f)
           jar.files[apply_pathmaps(config, f, :application)] = f
         end
-        bin_path = apply_pathmaps(config, default_executable, :application)
-        add_main_rb(jar, bin_path)
+
+        update_archive_add_executable(jar)
       end
 
       def default_executable
@@ -62,6 +63,7 @@ module Warbler
           exe
         end
       end
+
     end
   end
 end

--- a/lib/warbler/traits/nogemspec.rb
+++ b/lib/warbler/traits/nogemspec.rb
@@ -13,6 +13,7 @@ module Warbler
     class NoGemspec
       include Trait
       include PathmapHelper
+      include ExecutableHelper
 
       def self.detect?
         Jar.detect? && !Gemspec.detect?
@@ -29,7 +30,7 @@ module Warbler
       end
 
       def update_archive(jar)
-        add_main_rb(jar, apply_pathmaps(config, default_executable, :application))
+        update_archive_add_executable(jar)
       end
 
       def default_executable

--- a/spec/sample_jar/bin/another_jar
+++ b/spec/sample_jar/bin/another_jar
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'sample_jar'
+
+SampleJar.hello


### PR DESCRIPTION
allow for:
- specify custom executable
- executable from other gems to be used
- default (prefixed) parameters for the executable
- improved content tests (use `.should =~ ...` instead of `.grep(...).should_not be_empty`)

example `config/warble.rb` (requires a `Rakefile`):

``` ruby
Warbler::Config.new do |config|
  config.gems = [ "rake" ]
  config.executable = ["rake", "bin/rake"]
  config.executable_params = "do:something"
end
```
