### PR TITLE
Adjust to rubyzip 1.0 release (e.g. corrected incompatibilities)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source "http://rubygems.org/"
 
-gem 'rake', ">= 0.9.6"
-gem 'jruby-jars', ">= 1.5.6"
-gem 'jruby-rack', ">= 1.0.0"
-gem 'rubyzip', "~> 0.9"
+gemspec
 
 group :development do
   gem "jruby-openssl", :platform => :jruby

--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -5,7 +5,7 @@
 # See the file LICENSE.txt for details.
 #++
 
-require 'zip/zip'
+require 'zip'
 require 'stringio'
 require 'pathname'
 
@@ -203,7 +203,7 @@ module Warbler
     end
 
     def create_jar(jar_path, entries)
-      Zip::ZipFile.open(jar_path, Zip::ZipFile::CREATE) do |zipfile|
+      Zip::File.open(jar_path, Zip::File::CREATE) do |zipfile|
         entries.keys.sort.each do |entry|
           src = entries[entry]
           if src.respond_to?(:read)
@@ -224,7 +224,7 @@ module Warbler
     end
 
     def entry_in_jar(jar, entry)
-      Zip::ZipFile.open(jar) do |zf|
+      Zip::File.open(jar) do |zf|
         zf.get_input_stream(entry) {|io| StringIO.new(io.read) }
       end
     end

--- a/lib/warbler/traits/war.rb
+++ b/lib/warbler/traits/war.rb
@@ -144,7 +144,7 @@ module Warbler
           t = Tempfile.new(["empty", "jar"])
           path = t.path
           t.close!
-          Zip::ZipFile.open(path, Zip::ZipFile::CREATE) do |zipfile|
+          Zip::File.open(path, Zip::File::CREATE) do |zipfile|
             zipfile.mkdir("META-INF")
             zipfile.get_output_stream("META-INF/MANIFEST.MF") {|f| f << ::Warbler::Jar::DEFAULT_MANIFEST }
           end

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -129,7 +129,7 @@ describe Warbler::Jar do
 
       it "detects gem dependencies" do
         jar.apply(config)
-        file_list(%r{^gems/rubyzip.*/lib/zip/zip.rb}).should_not be_empty
+        file_list(%r{^gems/rubyzip.*/lib/zip.rb}).should_not be_empty
         file_list(%r{^specifications/rubyzip.*\.gemspec}).should_not be_empty
       end
 

--- a/spec/warbler/task_spec.rb
+++ b/spec/warbler/task_spec.rb
@@ -100,7 +100,7 @@ describe Warbler::Task do
 
     java_class_magic_number = [0xCA,0xFE,0xBA,0xBE].map { |magic_char| magic_char.chr }.join
 
-    Zip::ZipFile.open("#{config.jar_name}.war") do |zf|
+    Zip::File.open("#{config.jar_name}.war") do |zf|
       java_class_header     = zf.get_input_stream('WEB-INF/app/helpers/application_helper.class') {|io| io.read }[0..3]
       ruby_class_definition = zf.get_input_stream('WEB-INF/app/helpers/application_helper.rb') {|io| io.read }
 
@@ -116,7 +116,7 @@ describe Warbler::Task do
 
     java_class_magic_number = [0xCA,0xFE,0xBA,0xBE].map { |magic_char| magic_char.chr }.join
 
-    Zip::ZipFile.open("#{config.jar_name}.war") do |zf|
+    Zip::File.open("#{config.jar_name}.war") do |zf|
       java_class_header     = zf.get_input_stream('WEB-INF/lib/ruby_one_nine.class') {|io| io.read }[0..3]
       ruby_class_definition = zf.get_input_stream('WEB-INF/lib/ruby_one_nine.rb') {|io| io.read }
 
@@ -139,7 +139,7 @@ describe Warbler::Task do
         File.open("config/special.txt", "wb") {|f| f << "special"}
         Dir.chdir("config") { FileUtils.ln_s "special.txt", "link.txt" }
         silence { run_task "warble" }
-        Zip::ZipFile.open("#{config.jar_name}.war") do |zf|
+        Zip::File.open("#{config.jar_name}.war") do |zf|
           special = zf.get_input_stream('WEB-INF/config/special.txt') {|io| io.read }
           link = zf.get_input_stream('WEB-INF/config/link.txt') {|io| io.read }
           link.should == special
@@ -149,7 +149,7 @@ describe Warbler::Task do
       it "should process directory symlinks by copying the whole subdirectory" do
         Dir.chdir("lib") { FileUtils.ln_s "tasks", "rakelib" }
         silence { run_task "warble" }
-        Zip::ZipFile.open("#{config.jar_name}.war") do |zf|
+        Zip::File.open("#{config.jar_name}.war") do |zf|
           zf.find_entry("WEB-INF/lib/tasks/utils.rake").should_not be_nil
           zf.find_entry("WEB-INF/lib/rakelib/").should_not be_nil
           zf.find_entry("WEB-INF/lib/rakelib/utils.rake").should_not be_nil if defined?(JRUBY_VERSION)
@@ -183,7 +183,7 @@ describe Warbler::Task do
        silence { run_task "warble" } 
       end
       
-      Zip::ZipFile.open("#{config.jar_name}.war") do |zf|
+      Zip::File.open("#{config.jar_name}.war") do |zf|
         rspec = config.gems.keys.detect { |spec| spec.name == 'rspec' }
         rspec.should_not be_nil, "expected rspec gem among: #{config.gems.keys.join(' ')}"
         zf.find_entry("WEB-INF/gems/specifications/rspec-#{rspec.version}.gemspec").should_not be_nil

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -26,6 +26,6 @@ deployment to a Java environment.}
   gem.add_runtime_dependency 'rake', [">= 0.9.6"]
   gem.add_runtime_dependency 'jruby-jars', [">= 1.5.6"]
   gem.add_runtime_dependency 'jruby-rack', [">= 1.0.0"]
-  gem.add_runtime_dependency 'rubyzip', ["~> 0.9"]
+  gem.add_runtime_dependency 'rubyzip', [">= 1.0"]
   gem.add_development_dependency 'rspec', "~> 2.10"
 end


### PR DESCRIPTION
- had to adjust one spec that relied on internal rubyzip structure
  that changed
- removed duplicated gem dependencies from Gemfile to use gemspec,
  development gem group probably should also be defined there
- Addresses #190

Turns out I did have a little bit of time and the fix seems easy :-)

Cheers and thanks for warbler,
Tobi
