### PR TITLE
Reduce duplication between Gemfile and gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,9 @@
 source "http://rubygems.org/"
 
-gem 'rake', ">= 0.9.6"
-gem 'jruby-jars', ">= 1.5.6"
-gem 'jruby-rack', ">= 1.0.0"
-gem 'rubyzip', "~> 0.9"
+gemspec
 
 group :development do
   gem "jruby-openssl", :platform => :jruby
-  gem "rspec", ">= 2.8.0"
-  gem "diff-lcs"
   gem "rcov", ">= 0.9.8", :platform => :mri_18
-  gem "rdoc", ">= 2.4.2"
   gem "childprocess", :platform => :mri
 end

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -27,5 +27,7 @@ deployment to a Java environment.}
   gem.add_runtime_dependency 'jruby-jars', [">= 1.5.6"]
   gem.add_runtime_dependency 'jruby-rack', [">= 1.0.0"]
   gem.add_runtime_dependency 'rubyzip', ["~> 0.9"]
+
   gem.add_development_dependency 'rspec', "~> 2.10"
+  gem.add_development_dependency 'rdoc', ">= 2.4.2"
 end


### PR DESCRIPTION
There are still a few platform-specific items left in the Gemfile, but
everything else can be moved to the gemspec. Also removed the direct
reference to diff-lcs as Warbler doesn't use it directly.
