### PR TITLE
Invoke jrubyc using system to ensure that STDERR from jrubyc is shown

### DIFF
--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -50,7 +50,7 @@ module Warbler
         compat_version = ''
       end
       # Need to use the version of JRuby in the application to compile it
-      system %Q{java -classpath #{config.java_libs.join(File::PATH_SEPARATOR)} org.jruby.Main #{compat_version} -S jrubyc \"#{compiled_ruby_files.join('" "')}\"}
+      system %Q{env -i java -classpath #{config.java_libs.join(File::PATH_SEPARATOR)} org.jruby.Main #{compat_version} -S jrubyc \"#{compiled_ruby_files.join('" "')}\"}
       raise "Compile failed" if $?.exitstatus > 0
     end
 


### PR DESCRIPTION
I am experiencing issues with the 'jrubyc' process. To bring issues to the surface I recommend using system %Q{ } rather than %x{ }. Much to my surprise, under jruby (at least 1.7.8) %x{ } appears to flush STDERR!

I'd also highly recommend catching the exit status from jrubyc. The exitstatus is the number of files it did not compile. In this case there will be no class generated ... and with the ruby file a stub, well, you're SOL on that file. BTW, jrubyc will fail if there's a single syntax error in the file.

In my patch I have simply raised an exception but I expect you'd want to handle it more elegantly. 

Thanks!
