### PR TITLE
Specs and a possible fix for gemfile git entries

### DIFF
--- a/lib/warbler/templates/war.erb
+++ b/lib/warbler/templates/war.erb
@@ -2,7 +2,7 @@
 if $servlet_context.nil?
   ENV['GEM_HOME'] <%= assignment_operator %> File.expand_path('../../WEB-INF', __FILE__)
 <% if config.bundler && config.bundler[:gemfile_path] %>
-  ENV['BUNDLE_GEMFILE'] = File.expand_path('../../<%= config.bundler[:gemfile_path] %>', __FILE__)
+  ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../<%= config.bundler[:gemfile_path] %>', __FILE__)
 <% end %>
 else
   ENV['GEM_HOME'] <%= assignment_operator %> $servlet_context.getRealPath('<%= config.gem_path %>')


### PR DESCRIPTION
See issue jruby/warbler#165.
Fix spec for jruby: don't use `:err` for `IO.popen`
