### PR TITLE
Adds comment hinting at how to put a display name in web.xml.erb file.

### DIFF
--- a/web.xml.erb
+++ b/web.xml.erb
@@ -2,7 +2,7 @@
   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
   "http://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app>
-<!-- <display-name><%= (Rails rescue NameError) == NameError ? "" : Rails.application.class.parent %></display-name> -->
+<!-- <display-name>Uncomment and put name :here: for Tomcat Dashboard</display-name> -->
 
 <% webxml.context_params.each do |k,v| %>
   <context-param>


### PR DESCRIPTION
One line comment about display name for Tomcat Dashboard. Brainstormed ways of auto-generating this name but not successfull, better to just add a comment to hint to power users that it can be added to a web.xml.erb template. 

Thought about using Rails.application.class.parent but since that assumes a Rails env that would be bad. Plus if display-name appears in the web.xml it will likely be used over the filename by Tomcat. Settled on just adding a comment file to the file so that power users knows it exist and don't have to dig Tomcat config files like I had to. 
