### PR TITLE
Supresses a warning when using bundler

### DIFF
--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -62,9 +62,11 @@ module Warbler
             config.bundler[:git_specs] ||= []
             config.bundler[:git_specs] << spec
           when ::Bundler::Source::Path
-            $stderr.puts("warning: Bundler `path' components are not currently supported.",
-                         "The `#{spec.full_name}' component was not bundled.",
-                         "Your application may fail to boot!")
+            unless bundler_source_is_warbled_gem_itself?(spec.source)
+              $stderr.puts("warning: Bundler `path' components are not currently supported.",
+                           "The `#{spec.full_name}' component was not bundled.",
+                           "Your application may fail to boot!")
+            end
           else
             config.gems << spec
           end
@@ -140,6 +142,10 @@ module Warbler
         excluded_git_specs = (all - requested).select {|spec| ::Bundler::Source::Git === spec.source }
         excluded_git_specs.each {|spec| spec.groups << :warbler_excluded }
         requested + excluded_git_specs
+      end
+
+      def bundler_source_is_warbled_gem_itself?(source)
+        source.path.to_s == '.'
       end
     end
   end


### PR DESCRIPTION
Not sure if older versions of bundler did this as well in, but at least in recent versions there is always at least one gem at a local path used: The gem where bundle is just executed itself.

`Using warbler (1.4.1.dev) from source at .`

This always throws the warning, that this feature is not supported, but in that case I don't think this is necessary.
I can already see it happening when I run the `warbler` specs. All `Warbler::Config` specs output the following:

```
warning: Bundler `path' components are not currently supported.
The `warbler-1.4.1.dev' component was not bundled.
Your application may fail to boot!
```

This little addition supresses the warning when the gem at `'.'` is encountered. 
