### PR TITLE
jars from jruby.jar itself do not get copied over to WEB-INF/lib and thi...

### DIFF
--- a/lib/warbler/traits/war.rb
+++ b/lib/warbler/traits/war.rb
@@ -76,7 +76,7 @@ module Warbler
       def update_archive(jar)
         add_public_files(jar)
         add_webxml(jar)
-        move_jars_to_webinf_lib(jar)
+        #move_jars_to_webinf_lib(jar)
         add_runnables(jar) if config.features.include?("runnable")
         add_executables(jar) if config.features.include?("executable")
         add_gemjar(jar) if config.features.include?("gemjar")

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -550,26 +550,26 @@ describe Warbler::Jar do
       end
     end
 
-    context "with embedded jar files" do
-      before :each do
-        touch FileList["app/sample.jar", "lib/existing.jar"]
-      end
-      after :each do
-        rm_f FileList["app/sample.jar", "lib/existing.jar"]
-      end
+    # context "with embedded jar files" do
+    #   before :each do
+    #     touch FileList["app/sample.jar", "lib/existing.jar"]
+    #   end
+    #   after :each do
+    #     rm_f FileList["app/sample.jar", "lib/existing.jar"]
+    #   end
 
-      it "moves jar files to WEB-INF/lib" do
-        jar.apply(config)
-        file_list(%r{WEB-INF/lib/app-sample.jar}).should_not be_empty
-        file_list(%r{WEB-INF/app/sample.jar}).should_not be_empty
-      end
+    #   it "moves jar files to WEB-INF/lib" do
+    #     jar.apply(config)
+    #     file_list(%r{WEB-INF/lib/app-sample.jar}).should_not be_empty
+    #     file_list(%r{WEB-INF/app/sample.jar}).should_not be_empty
+    #   end
 
-      it "leaves jar files alone that are already in WEB-INF/lib" do
-        jar.apply(config)
-        file_list(%r{WEB-INF/lib/lib-existing.jar}).should be_empty
-        file_list(%r{WEB-INF/lib/existing.jar}).should_not be_empty
-      end
-    end
+    #   it "leaves jar files alone that are already in WEB-INF/lib" do
+    #     jar.apply(config)
+    #     file_list(%r{WEB-INF/lib/lib-existing.jar}).should be_empty
+    #     file_list(%r{WEB-INF/lib/existing.jar}).should_not be_empty
+    #   end
+    # end
 
     context "with the executable feature" do
       use_test_webserver


### PR DESCRIPTION
...ngs work just fine with the vendored jars inside the gems. fix issue https://github.com/jruby/jruby/issues/1435 and others maybe.

currently I just comment out the respective code since there was a reason to include that code. but the problem is that such a copying of jars will divert for example from
$ jruby -S rails server
drastically. I haven't look into how executable jars are packed, i.e. whether they unpack the vendored jars as well.

I think actually the opposite approach would be actually better: to separate the jruby-classloader from its parent classloader, similar what you can configure with servlet-classloader to load its classes first to avoid clashed with the underlying parent-classloader. maven also separates the plugin from each other with the trick.

on the other hand I would not know how to extract the jars from jruby-stdlib-complete or jruby-complete or whatever jruby jars you have configured.

further the current setup duplicates the jars from jruby-jars.gem on fresh rails setup (rails new foobar; cd foobar; warble)

from my personal experience I used a simple maven setup to pack a warfile which always worked on jetty.
