### PR TITLE
Update README.rdoc to not require warbler in Gemfile

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -226,7 +226,7 @@ simply add the following code somewhere in the +Rakefile+ :
 If you're using Bundler, you'll want to add Warbler to your +Gemfile+ :
 
     group :development do
-      gem "warbler"
+      gem "warbler", :require => false
     end
 
 Now you should be able to invoke <tt>rake war</tt> to create your war file.


### PR DESCRIPTION
Warbler is either used as a command or in rake, where it can be required. Therefore, we can save some performance by not requiring it in Gemfile.
