### PR TITLE
Can't convert TrueClass into String

### DIFF
--- a/lib/warbler/templates/jbundler.erb
+++ b/lib/warbler/templates/jbundler.erb
@@ -1,2 +1,2 @@
 # the jars are already loaded via the servlet classloader
-ENV['JBUNDLE_SKIP'] = true
+ENV['JBUNDLE_SKIP'] = 'true'

--- a/spec/warbler/jbundler_spec.rb
+++ b/spec/warbler/jbundler_spec.rb
@@ -54,7 +54,7 @@ describe Warbler::Jar, "with JBundler" do
     it "adds JBUNDLE_SKIP to init.rb" do
       jar.add_init_file(config)
       contents = jar.contents('META-INF/init.rb')
-      contents.should =~ /ENV\['JBUNDLE_SKIP'\]/
+      contents.should =~ /ENV\['JBUNDLE_SKIP'\] = 'true'/
     end
 
     it "uses ENV['JBUNDLE_JARFILE'] if set" do


### PR DESCRIPTION
After creating an executable using Warbler, I get the following error when running the JAR:

```
TypeError: can't convert TrueClass into String
   (root) at file:/[path]/app/app.jar!/META-INF/init.rb:14
  require at org/jruby/RubyKernel.java:1065
   (root) at file:/var/folders/f2/9k757ht96kndfnvlmfhx5bp00000gn/T/jruby3396284761916552030extract/jruby-complete-1.7.12.jar!/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1
  require at file:/var/folders/f2/9k757ht96kndfnvlmfhx5bp00000gn/T/jruby3396284761916552030extract/jruby-complete-1.7.12.jar!/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55
error: org.jruby.embed.EvalFailedException: (TypeError) can't convert TrueClass into String
```

This is the contents of `META-INF/init.rb` from the extracted JAR:

```
WARBLER_CONFIG = {}


ENV['GEM_HOME'] = File.expand_path('../..', __FILE__)


ENV['BUNDLE_GEMFILE'] = File.expand_path('../../app/Gemfile', __FILE__)

ENV['BUNDLE_WITHOUT'] = 'development:test:assets'

$LOAD_PATH.unshift __FILE__.sub(/!.*/, '!/app/lib')
require 'rubygems'
# the jars are already loaded via the servlet classloader
ENV['JBUNDLE_SKIP'] = true
```

I'm not sure why `ENV['JBUNDLE_SKIP'] = true` would cause this error. I am using jbundler to include JAR dependencies.
