### PR TITLE
don't swallow compiler errors with backticks

### DIFF
--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -63,7 +63,7 @@ module Warbler
         # Need to use the version of JRuby in the application to compile it
         javac_cmd = %Q{java -classpath #{config.java_libs.join(File::PATH_SEPARATOR)} #{java_version(config)} org.jruby.Main #{compat_version} -S jrubyc \"#{slice.join('" "')}\"}
         if which('env')
-          `env -i #{javac_cmd}`
+          system %Q{env -i #{javac_cmd}}
         else
           system javac_cmd
         end


### PR DESCRIPTION
backticks swallow every output of javac - making it pretty much impossible to debug compiling errors.
