### PR TITLE
config.webserver = 'jetty' (by default)

### DIFF
--- a/ext/WarblerJar.java
+++ b/ext/WarblerJar.java
@@ -37,8 +37,9 @@ public class WarblerJar {
     }
 
     @JRubyMethod
-    public static IRubyObject create_jar(ThreadContext context, IRubyObject recv, IRubyObject jar_path, IRubyObject entries) {
-        final Ruby runtime = recv.getRuntime();
+    public static IRubyObject create_jar(ThreadContext context, IRubyObject self,
+        IRubyObject jar_path, IRubyObject entries) {
+        final Ruby runtime = context.runtime;
 
         if (!(entries instanceof RubyHash)) {
             throw runtime.newArgumentError("expected a hash for the second argument");
@@ -56,7 +57,7 @@ public class WarblerJar {
             }
         } catch (IOException e) {
             if (runtime.isDebug()) {
-                e.printStackTrace();
+                e.printStackTrace(runtime.getOut());
             }
             throw runtime.newIOErrorFromException(e);
         }
@@ -65,8 +66,9 @@ public class WarblerJar {
     }
 
     @JRubyMethod
-    public static IRubyObject entry_in_jar(ThreadContext context, IRubyObject recv, IRubyObject jar_path, IRubyObject entry) {
-        final Ruby runtime = recv.getRuntime();
+    public static IRubyObject entry_in_jar(ThreadContext context, IRubyObject self,
+        IRubyObject jar_path, IRubyObject entry) {
+        final Ruby runtime = context.runtime;
         try {
             InputStream entryStream = getStream(jar_path.convertToString().getUnicodeValue(),
                                                 entry.convertToString().getUnicodeValue());
@@ -84,7 +86,7 @@ public class WarblerJar {
             }
         } catch (IOException e) {
             if (runtime.isDebug()) {
-                e.printStackTrace();
+                e.printStackTrace(runtime.getOut());
             }
             throw runtime.newIOErrorFromException(e);
         }
@@ -120,7 +122,7 @@ public class WarblerJar {
                 try {
                     zip.putNextEntry(new ZipEntry(entryName));
                     byte[] buf = new byte[16384];
-                    int bytesRead = -1;
+                    int bytesRead;
                     while ((bytesRead = inFile.read(buf)) != -1) {
                         zip.write(buf, 0, bytesRead);
                     }
@@ -181,7 +183,7 @@ public class WarblerJar {
         entry = trimTrailingSlashes(entry);
 
         ZipInputStream jstream = new ZipInputStream(jar);
-        ZipEntry zentry = null;
+        ZipEntry zentry;
         while ((zentry = jstream.getNextEntry()) != null) {
             if (trimTrailingSlashes(zentry.getName()).equals(entry)) {
                 return jstream;

--- a/lib/warbler/web_server.rb
+++ b/lib/warbler/web_server.rb
@@ -1,12 +1,13 @@
 module Warbler
   class WebServer
     class Artifact < Struct.new(:repo, :group_id, :artifact_id, :version)
+
       def path_fragment
         @path_fragment ||= "#{group_id.gsub('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.jar"
       end
 
       def cached_path
-        @cached_path ||= File.expand_path("~/.m2/repository/#{path_fragment}")
+        @cached_path ||= File.join(local_repository, path_fragment)
       end
 
       def download_url
@@ -33,6 +34,11 @@ module Warbler
         end
         cached_path
       end
+
+      def local_repository
+        File.expand_path('~/.m2/repository')
+      end
+
     end
 
     def add(jar)
@@ -90,9 +96,9 @@ PROPS
     end
   end
 
-  WEB_SERVERS = Hash.new {|h,k| h["jenkins-ci.winstone"] }
-  WEB_SERVERS.update({ "winstone" => WinstoneServer.new,
-                       "jenkins-ci.winstone" => JenkinsWinstoneServer.new,
-                       "jetty" => JettyServer.new
-                     })
+  WEB_SERVERS = Hash.new { |hash,_| hash['jetty'] }
+  WEB_SERVERS['winstone'] = WinstoneServer.new
+  WEB_SERVERS['jenkins-ci.winstone'] = JenkinsWinstoneServer.new,
+  WEB_SERVERS['jetty'] = JettyServer.new
+
 end

--- a/spec/m2_home/conf/settings.xml
+++ b/spec/m2_home/conf/settings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+  <profiles>
+    <profile>
+      <id>codehaus</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>codehaus</id>
+          <name>Codehaus Repository</name>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <url>http://repository.codehaus.org</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <localRepository>/usr/local/maven/repo</localRepository>
+</settings>

--- a/spec/warbler/web_server_spec.rb
+++ b/spec/warbler/web_server_spec.rb
@@ -1,0 +1,41 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+class Warbler::WebServer::Artifact
+  def self.reset_local_repository
+    @@local_repository = nil
+  end
+end
+
+describe Warbler::WebServer::Artifact do
+
+  @@_env = ENV.dup
+
+  after(:all) { ENV.clear; ENV.update @@_env }
+
+  before do
+    Warbler::WebServer::Artifact.reset_local_repository
+  end
+
+  after(:all) do
+    Warbler::WebServer::Artifact.reset_local_repository
+  end
+
+  let(:sample_artifact) do
+    Warbler::WebServer::Artifact.new("http://repo.jenkins-ci.org/public",
+      "org.jenkins-ci", "winstone", "0.9.10-jenkins-43"
+    )
+  end
+
+  it "uses default (maven) local repository" do
+    ENV['HOME'] = '/home/borg'
+    ENV.delete('M2_HOME'); ENV.delete('MAVEN_HOME')
+    expect( sample_artifact.local_repository ).to eql "/home/borg/.m2/repository"
+  end
+
+  it "detects a custom maven repository setting" do
+    ENV['HOME'] = '/home/borg'
+    ENV['M2_HOME'] = File.expand_path('../m2_home', File.dirname(__FILE__))
+    expect( sample_artifact.local_repository ).to eql '/usr/local/maven/repo'
+  end
+
+end

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -25,7 +25,7 @@ bundle up all of your application files for deployment to a Java environment.}
   gem.add_runtime_dependency 'rake', [">= 0.9.6"]
   # restrict it for maven not to find jruby-9000.dev
   gem.add_runtime_dependency 'jruby-jars', [">= 1.5.6", '< 2.0']
-  gem.add_runtime_dependency 'jruby-rack', [">= 1.0.0"]
+  gem.add_runtime_dependency 'jruby-rack', [">= 1.1.1", '< 1.3']
   gem.add_runtime_dependency 'rubyzip', [">= 0.9", "< 1.2"]
   gem.add_development_dependency 'jbundler', "~> 0.5.5"
   gem.add_development_dependency 'ruby-maven', '~> 3.1.1.0'


### PR DESCRIPTION
... still using an old jetty version which for updating needs us to publish a maven artifact
but that Jetty is still newer that Winstone, which somehow stayed in 2008!

there's some additional cleanup, namely : 
- jruby-rack gem should have stricter requirements
- improved "MAVEN_REPO" detection for cached webserver .jar
- as well as error/stack trace printing

hopefully I get some more time later and continue with : 
- refactoring the packaged jetty if possible (so it can be updated by simply changing a version number)
- review Jar/WarMain there are some stack-traces that should be reviewed (running with *warbler.debug=true*)