### PR TITLE
Wrong default GEM_HOME in generated META-INF/init.rb

### DIFF
--- a/lib/warbler/templates/war.erb
+++ b/lib/warbler/templates/war.erb
@@ -1,8 +1,8 @@
 <% assignment_operator = config.override_gem_home ? "=" : "||=" %>
 if $servlet_context.nil?
-  ENV['GEM_HOME'] <%= assignment_operator %> File.expand_path('../../WEB-INF', __FILE__)
+  ENV['GEM_HOME'] <%= assignment_operator %> File.expand_path(File.join('..', '..', '<%= config.gem_path %>'), __FILE__)
 <% if config.bundler && config.bundler[:gemfile_path] %>
-  ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../<%= config.bundler[:gemfile_path] %>', __FILE__)
+  ENV['BUNDLE_GEMFILE'] ||= File.expand_path(File.join('..', '..', '<%= config.bundler[:gemfile_path] %>'), __FILE__)
 <% end %>
 else
   ENV['GEM_HOME'] <%= assignment_operator %> $servlet_context.getRealPath('<%= config.gem_path %>')


### PR DESCRIPTION
Was generating the following: (default config.gem_path is WEB-INF/gems though)

if $servlet_context.nil?
  ENV['GEM_HOME'] = File.expand_path('../../WEB-INF', **FILE**)
  ...

After:

if $servlet_context.nil?
  ENV['GEM_HOME'] = File.expand_path(File.join('..', '..', '/WEB-INF/gems'), **FILE**)
  ...
