### PR TITLE
Use a topological sort to order traits by requirements.

### DIFF
--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -17,8 +17,8 @@ module Warbler
         File.exist?(ENV['BUNDLE_GEMFILE'] || "Gemfile")
       end
 
-      def self.requires?(trait)
-        trait == Traits::War || trait == Traits::Jar
+      def self.requirements
+        [ Traits::War, Traits::Jar ]
       end
 
       def before_configure

--- a/lib/warbler/traits/jbundler.rb
+++ b/lib/warbler/traits/jbundler.rb
@@ -17,8 +17,8 @@ module Warbler
         File.exist?(ENV['JBUNDLE_JARFILE'] || "Jarfile")
       end
 
-      def self.requires?(trait)
-        trait == Traits::War || trait == Traits::Jar
+      def self.requirements
+        [ Traits::War, Traits::Jar ]
       end
 
       def before_configure

--- a/lib/warbler/traits/merb.rb
+++ b/lib/warbler/traits/merb.rb
@@ -15,8 +15,8 @@ module Warbler
         File.exist?("config/init.rb")
       end
 
-      def self.requires?(trait)
-        trait == Traits::War
+      def self.requirements
+        [ Traits::War ]
       end
 
       def before_configure

--- a/lib/warbler/traits/rack.rb
+++ b/lib/warbler/traits/rack.rb
@@ -15,8 +15,8 @@ module Warbler
         !Rails.detect? && (File.exist?("config.ru") || !Dir['*/config.ru'].empty?)
       end
 
-      def self.requires?(trait)
-        trait == Traits::War
+      def self.requirements
+        [ Traits::War ]
       end
 
       def before_configure

--- a/lib/warbler/traits/rails.rb
+++ b/lib/warbler/traits/rails.rb
@@ -15,8 +15,8 @@ module Warbler
         File.exist?("config/environment.rb")
       end
 
-      def self.requires?(trait)
-        trait == Traits::War
+      def self.requirements
+        [ Traits::War ]
       end
 
       def before_configure

--- a/spec/warbler/traits_spec.rb
+++ b/spec/warbler/traits_spec.rb
@@ -9,9 +9,13 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 describe Warbler::Traits do
   it "are ordered by fewer dependencies first" do
-    traits = [Warbler::Traits::War, Warbler::Traits::Bundler, Warbler::Traits::Rails]
-    result = traits.shuffle.sort
-    result.index(Warbler::Traits::War).should < result.index(Warbler::Traits::Bundler)
-    result.index(Warbler::Traits::War).should < result.index(Warbler::Traits::Rails)
+    traits = Warbler::TraitsDependencyArray.new( Warbler::Traits.constants.map {|t| Warbler::Traits.const_get(t)})
+    result = traits.shuffle!.tsort
+
+    result.each do |trait|
+      trait.requirements.each do |requirement|
+        result.index(requirement).should < result.index(trait)
+      end
+    end
   end
 end


### PR DESCRIPTION
The original sort using a comparator does not work as required here. For
example, both (Rack <=> Jar) and (Jar <=> War) are 0 (since neither depends on
the other). By the rules of sort, this should imply that (Rack <=> War) is also
zero, since sort requires the comparator be transitive. However, this is not
true, as Rack depends on War.

This patch fixes this problem by using tsort, which is the appropriate mechanism
for sorting DAGs like trait requirements.
