### PR TITLE
enable ENV['RACK_ENV'] to honor command line environment variable

### DIFF
--- a/lib/warbler/templates/rack.erb
+++ b/lib/warbler/templates/rack.erb
@@ -1,3 +1,3 @@
-ENV['RACK_ENV'] = '<%= (params = config.webxml.context_params; params['rack.env']) %>'
+ENV['RACK_ENV'] ||= '<%= (params = config.webxml.context_params; params['rack.env']) %>'
 
 $LOAD_PATH.unshift $servlet_context.getRealPath('/WEB-INF') if $servlet_context


### PR DESCRIPTION
currently, in a war packaged by warbler, the only source of ENV['RACK_ENV'] is the `rack.env` context-param. this means the same war file can't be used for multiple environments. 

This PR enables RACK_ENV environment variable to take precedence.