### PR TITLE
warbler.rb: Document jar_extension, autodeploy_dir options

### DIFF
--- a/warble.rb
+++ b/warble.rb
@@ -80,6 +80,12 @@ Warbler::Config.new do |config|
   # of the project directory.
   # config.jar_name = "mywar"
 
+  # File extension for the archive. Defaults to either 'jar' or 'war'.
+  # config.jar_extension = "jar"
+
+  # Destionation for the created archive. Defaults to project's root directory.
+  # config.autodeploy_dir = "dist/"
+
   # Name of the MANIFEST.MF template for the war file. Defaults to a simple
   # MANIFEST.MF that contains the version of Warbler used to create the war file.
   # config.manifest_file = "config/MANIFEST.MF"


### PR DESCRIPTION
I only learned about the existence of the `autodeploy_dir` configuration directory by examining the [Warbler::Jar#create](https://github.com/jruby/warbler/blob/575fd97ccfcec84ce4cf0b376a56ef72d406776f/lib/warbler/jar.rb#L153) code.

IMO, it should be documented as comments in the `config/warble.rb` file template.