### PR TITLE
Fixes 268:  Don't clear the environment if a java executable is found

### DIFF
--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -62,7 +62,7 @@ module Warbler
       compiled_ruby_files.each_slice(2500) do |slice|
         # Need to use the version of JRuby in the application to compile it
         javac_cmd = %Q{java -classpath #{config.java_libs.join(File::PATH_SEPARATOR)} #{java_version(config)} org.jruby.Main #{compat_version} -S jrubyc \"#{slice.join('" "')}\"}
-        if which('env')
+        if which('java').nil? && which('env')
           system %Q{env -i #{javac_cmd}}
         else
           system javac_cmd


### PR DESCRIPTION
The `env -i` was added to work around an issue where bundler apparently
munged the environment such that the java executable could not be found
without clearing the environment.  However, the `env -i` code branch is
_always_ executed if an env executable is available, which causes compile
to break in environments where there is no java on the default path.

This narrows the scope of that change by checking if there is a java on
the path.  If a java executable is found on the path, that java will be
used; if not, Warbler falls back to the previous behavior of checking
for an env executable, and using `env -i` if an env executable is found.