### PR TITLE
Sprockets manifest name change

### DIFF
--- a/lib/warbler/traits/rails.rb
+++ b/lib/warbler/traits/rails.rb
@@ -50,6 +50,7 @@ module Warbler
           config.webxml.jruby.max.runtimes = 1 unless Integer === config.webxml.jruby.max.runtimes
         end
 
+        config.includes += FileList["public/assets/.sprockets-manifest-*.json"].existing
         config.includes += FileList["public/assets/manifest-*.json"].existing
         config.includes += FileList["public/assets/manifest.yml"].existing
       end

--- a/lib/warbler/traits/war.rb
+++ b/lib/warbler/traits/war.rb
@@ -27,7 +27,7 @@ module Warbler
         config.webxml        = default_webxml_config
         config.webinf_files  = default_webinf_files
         config.java_libs     = default_jar_files
-        config.public_html   = FileList["public/**/*"]
+        config.public_html   = FileList["public/**/{.[!.],.??*,*}"] # include dotfiles
         config.jar_extension = 'war'
         config.init_contents << "#{config.warbler_templates}/war.erb"
       end

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -801,7 +801,7 @@ describe Warbler::Jar do
 
       context "with rails version 4" do
 
-        let (:manifest_file) { "public/assets/manifest-1234.json" }
+        let (:manifest_file) { "public/assets/.sprockets-manifest-1234.json" }
 
         shared_examples_for "asset pipeline" do
           it "automatically adds asset pipeline manifest file to the included files" do


### PR DESCRIPTION
Sprockets 3 changed the generated assets manifest filename from manifest-*.json to .sprockets-manifest-*.json.