### PR TITLE
adds capacity for jruby-jars gem for jruby-9k

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -4,6 +4,7 @@
 - #313: Update Jetty to 9.2.10
 - #311: Don't clear the environment if a java executable is found
 - #268: Compile's clearing of ENV vars makes it impossible to use custom compile vars
+- Adds capacity to use the jruby-jars gem version for JRuby 9k.
 
 == 1.4.5
 - #282: Wrong default GEM_HOME in generated META-INF/init.rb

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -24,7 +24,7 @@ bundle up all of your application files for deployment to a Java environment.}
 
   gem.add_runtime_dependency 'rake', [">= 0.9.6"]
   # restrict it for maven not to find jruby-9000.dev
-  if /\A9\.[0-9]\.[0-9]{1,2}\.[0-9]{1,2}\.?(pre[1-9]{1})?\z/.match(JRUBY_VERSION)
+  if defined?(JRUBY_VERSION) && /\A9\.[0-9]\.[0-9]{1,2}\.[0-9]{1,2}\.?(pre[1-9]{1})?\z/.match(JRUBY_VERSION)
     #if using jruby-9k
     gem.add_runtime_dependency 'jruby-jars', [JRUBY_VERSION]
   else

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -24,7 +24,12 @@ bundle up all of your application files for deployment to a Java environment.}
 
   gem.add_runtime_dependency 'rake', [">= 0.9.6"]
   # restrict it for maven not to find jruby-9000.dev
-  gem.add_runtime_dependency 'jruby-jars', [">= 1.5.6", '< 2.0']
+  if /\A9\.[0-9]\.[0-9]{1,2}\.[0-9]{1,2}\.?(pre[1-9]{1})?\z/.match(JRUBY_VERSION)
+    #if using jruby-9k
+    gem.add_runtime_dependency 'jruby-jars', [JRUBY_VERSION]
+  else
+    gem.add_runtime_dependency 'jruby-jars', [">= 1.5.6", '< 2.0'] 
+  end
   gem.add_runtime_dependency 'jruby-rack', [">= 1.1.1", '< 1.3']
   gem.add_runtime_dependency 'rubyzip', [">= 0.9", "< 1.2"]
   gem.add_development_dependency 'jbundler', "~> 0.5.5"


### PR DESCRIPTION
Hi,
I changed the gemspec requirements so warbler would work with jruby-9k jars including the preview release. It uses a regular expression to see if you are using jruby-9k and then uses that version as the gemspec for jruby-jars. It's a little hacky but it works. One must then use bundle exec warble to test.

Produces this warning: 
`file:/Users/name/.rvm/rubies/jruby-9.0.0.0.pre1/lib/jruby.jar!/jruby/kernel/kernel.rb:28: warning: unsupported exec option: close_others`
but works anyway. 

Thanks,

David Acevedo
