### PR TITLE
polish *scripts/rails* - require_relative should no longer be used

### DIFF
--- a/lib/warbler/scripts/rails.rb
+++ b/lib/warbler/scripts/rails.rb
@@ -1,11 +1,5 @@
 #!/usr/bin/env ruby
 
-if RUBY_VERSION =~ /^1.8/
-  APP_PATH = File.expand_path('../../config/application',  __FILE__)
-  require File.expand_path('../../config/boot',  __FILE__)
-  require 'rails/commands' 
-else
-  APP_PATH = File.expand_path('../../config/application',  __FILE__)
-  require_relative '../config/boot'
-  require 'rails/commands'
-end
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require File.expand_path('../../config/boot',  __FILE__)
+require 'rails/commands'


### PR DESCRIPTION
on Ruby 2.x (was only available in 1.9.3)