### PR TITLE
Fix #169: Automatically include the .sprockets-manifest-*.json file

### DIFF
--- a/lib/warbler/traits/rails.rb
+++ b/lib/warbler/traits/rails.rb
@@ -50,6 +50,7 @@ module Warbler
           config.webxml.jruby.max.runtimes = 1 unless Integer === config.webxml.jruby.max.runtimes
         end
 
+        config.includes += FileList["public/assets/.sprockets-manifest-*.json"].existing
         config.includes += FileList["public/assets/manifest-*.json"].existing
         config.includes += FileList["public/assets/manifest.yml"].existing
       end

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -802,20 +802,24 @@ describe Warbler::Jar do
       context "with rails version 4" do
 
         let (:manifest_file) { "public/assets/manifest-1234.json" }
+        let (:sprockets_manifest_file) { "public/assets/.sprockets-manifest-1234.json" }
 
         shared_examples_for "asset pipeline" do
           it "automatically adds asset pipeline manifest file to the included files" do
             config.includes.should include(manifest_file)
+            config.includes.should include(sprockets_manifest_file)
           end
         end
 
         before do
           mkdir File.dirname(manifest_file)
           File.open(manifest_file, "w")
+          File.open(sprockets_manifest_file, "w")
         end
 
         after do
           rm_rf File.dirname(manifest_file)
+          rm_rf File.dirname(sprockets_manifest_file)
         end
 
         context "When rails version is specified in Gemfile" do


### PR DESCRIPTION
The default asset manifest was recently renamed from `manifest-*.json` to `.sprockets-manifest-*.json` for sprockets 3+.  This updates warbler to automatically include the new manifest.