### PR TITLE
Allow version ~> 1.2 of rubyzip. More ...

### DIFF
--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -183,7 +183,7 @@ describe Warbler::Jar do
         jar.compile(config)
         jar.apply(config)
         file_list(%r{sample_jar.*\.rb$}).size.should == 2
-        file_list(%r{gems.*\.class$}).size.should == 80
+        file_list(%r{gems.*\.class$}).size.should == 83
       end
 
       it "does not compile included gems by default" do

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -25,7 +25,7 @@ bundle up all of your application files for deployment to a Java environment.}
   gem.add_runtime_dependency 'rake', [">= 10.1.0"]
   gem.add_runtime_dependency 'jruby-jars', [">= 9.0.0.0"]
   gem.add_runtime_dependency 'jruby-rack', [">= 1.1.1", '< 1.3']
-  gem.add_runtime_dependency 'rubyzip', [">= 1.0", "< 1.2"]
+  gem.add_runtime_dependency 'rubyzip', "~> 1.0"
   gem.add_development_dependency 'jbundler', "~> 0.9"
   gem.add_development_dependency 'rspec', "~> 2.10"
   gem.add_development_dependency 'rdoc', ">= 2.4.2"


### PR DESCRIPTION
Rubyzip 1.2.0 includes a change which does not enable JRuby.objectspace. https://github.com/rubyzip/rubyzip/pull/252
Which fixes the following warning:
> warning: ObjectSpace impacts performance. See http://wiki.jruby.org/PerformanceTuning#dont-enable-objectspace

The jar_spec.rb change was made since three new classes have been added:
gems/rubyzip-1.2.0/test/case_sensitivity_test.class
gems/rubyzip-1.2.0/test/file_permissions_test.class
gems/rubyzip-1.2.0/test/samples/example_recursive_test.class