### PR TITLE
limit rubyzip version to not match too far

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ group :development do
   gem "rcov", ">= 0.9.8", :platform => :mri_18
   gem "childprocess", :platform => :mri
 end
+
+gem 'rubyzip', ENV['RUBYZIP_VERSION'] if ENV['RUBYZIP_VERSION']

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -183,7 +183,7 @@ describe Warbler::Jar do
         jar.compile(config)
         jar.apply(config)
         file_list(%r{sample_jar.*\.rb$}).size.should == 2
-        file_list(%r{gems.*\.class$}).size.should == 83
+        file_list(%r{gems.*\.class$}).size.should >= 80 # depending on RubyZip version
       end
 
       it "does not compile included gems by default" do

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -24,8 +24,8 @@ bundle up all of your application files for deployment to a Java environment.}
 
   gem.add_runtime_dependency 'rake', [">= 10.1.0"]
   gem.add_runtime_dependency 'jruby-jars', [">= 9.0.0.0"]
-  gem.add_runtime_dependency 'jruby-rack', [">= 1.1.1", '< 1.3']
-  gem.add_runtime_dependency 'rubyzip', "~> 1.0"
+  gem.add_runtime_dependency 'jruby-rack', [">= 1.1.1", "< 1.3"]
+  gem.add_runtime_dependency 'rubyzip', ["~> 1.0", "< 1.4"]
   gem.add_development_dependency 'jbundler', "~> 0.9"
   gem.add_development_dependency 'rspec', "~> 2.10"
   gem.add_development_dependency 'rdoc', ">= 2.4.2"


### PR DESCRIPTION
and allow specs to pass with supported gem versions

also wanted to ask if its ok if I back-port allowing 1.2 to Warbler 1.4 (due the earlier versions enabling ObjectSpace on JRuby)?