### PR TITLE
[backport] support for running with (recent) rubyzip 1.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ group :development do
   gem "maven-tools", "~> 0.34.5"
 end
 
-if RUBY_VERSION < "1.9"
+if ENV['RUBYZIP_VERSION']
+  gem 'rubyzip', ENV['RUBYZIP_VERSION']
+elsif RUBY_VERSION < "1.9"
   gem 'rubyzip', '~> 0.9'
 end

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -184,7 +184,7 @@ describe Warbler::Jar do
         jar.apply(config)
         file_list(%r{sample_jar.*\.rb$}).size.should == 2
         if RUBY_VERSION >= '1.9'
-          file_list(%r{gems.*\.class$}).size.should == 80
+          file_list(%r{gems.*\.class$}).size.should >= 80 # depending on RubyZip version
         else
           # 1.8.7 uses an older version of rubyzip and so the number of files compiled changes
           file_list(%r{gems.*\.class$}).size.should == 32

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -26,7 +26,7 @@ bundle up all of your application files for deployment to a Java environment.}
   # restrict it for maven not to find jruby-9000.dev
   gem.add_runtime_dependency 'jruby-jars', [">= 1.5.6", '< 2.0']
   gem.add_runtime_dependency 'jruby-rack', [">= 1.1.1", '< 1.3']
-  gem.add_runtime_dependency 'rubyzip', [">= 0.9", "< 1.2"]
+  gem.add_runtime_dependency 'rubyzip', [">= 0.9", "< 1.3"]
   gem.add_development_dependency 'jbundler', "~> 0.5.5"
   gem.add_development_dependency 'ruby-maven', '~> 3.1.1.0'
   gem.add_development_dependency 'rspec', "~> 2.10"


### PR DESCRIPTION
... mostly the same as on **2.x-dev**, commits :


- Allow version 1.x of rubyzip. More ...

Rubyzip 1.2.0 includes a fix which does not enable JRuby.objectspace.

The jar_spec.rb change was made since three new classes have been added:
gems/rubyzip-1.2.0/test/case_sensitivity_test.class
gems/rubyzip-1.2.0/test/file_permissions_test.class
gems/rubyzip-1.2.0/test/samples/example_recursive_test.class

- spec should still handle local locked rubyzip < 1.2.0
- allow to bundle and run against set RUBYZIP_VERSION
- potentially limit rubyzip gem version to not get too far