### PR TITLE
exclude spec/integration/rakelib and dot-files being packed into .gem

### DIFF
--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -15,7 +15,11 @@ Gem::Specification.new do |gem|
 Rails, or Rack application. Warbler provides a minimal, flexible, Ruby-like way to
 bundle up all of your application files for deployment to a Java environment.}
 
-  gem.files         = `git ls-files`.split("\n")
+  gem.files         = `git ls-files`.split("\n").
+    reject { |file| file =~ /^\./ }. # .gitignore, .travis.yml
+    reject { |file| file =~ /^spec|test\// }. # spec/**/*.spec
+    reject { |file| file =~ /^integration\// }. # (un-used) *.rake files
+    reject { |file| file =~ /^rakelib\// } # (un-used) *.rake files
   gem.test_files    = `git ls-files -- {test,spec,features,integration}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]


### PR DESCRIPTION
2.0.0 -> 2.0.1 has seen an increased release asset file (due some new spec)!
**331k -> 776k** https://rubygems.org/gems/warbler

we shall be now at a much more reasonable 76k (including ext .java files)

any objections against this ? // cc @mkristian @jkutner 

heh ... also avoids/fixes #256