### PR TITLE
Allow override for webserver.properties

### DIFF
--- a/lib/warbler/web_server.rb
+++ b/lib/warbler/web_server.rb
@@ -103,7 +103,7 @@ module Warbler
 </Configure>
 CONFIG
 
-      jar.files["WEB-INF/webserver.properties"] = StringIO.new(<<-PROPS)
+      jar.files["WEB-INF/webserver.properties"] ||= StringIO.new(<<-PROPS)
 mainclass = org.eclipse.jetty.runner.Runner
 args = args0,args1,args2,args3,args4,args5,args6
 props = jetty.home


### PR DESCRIPTION
For my use case, I wanted to run a Jetty server with stats reporting via Prometheus client. I was already able to configure `webserver.xml` to make Jetty boot Prometheus. Then I also needed to override `webserver.properties` so that Jetty included the Prometheus jar.