### PR TITLE
Added Gem.reload_paths to fix issue with deploying with 9.2.x

### DIFF
--- a/lib/warbler/templates/bundler.erb
+++ b/lib/warbler/templates/bundler.erb
@@ -16,4 +16,6 @@ module Bundler
   end
 end
 
+Gem.reload_paths
+
 require 'bundler/shared_helpers'


### PR DESCRIPTION
This is a quick fix for https://github.com/jruby/warbler/issues/432 and https://github.com/jruby/warbler/issues/430
