### PR TITLE
Revert "[fix] gem path reloading when delpoying on 9.2.x (#433)" 

### DIFF
--- a/lib/warbler/templates/bundler.erb
+++ b/lib/warbler/templates/bundler.erb
@@ -16,6 +16,4 @@ module Bundler
   end
 end
 
-Gem.reload_paths
-
 require 'bundler/shared_helpers'


### PR DESCRIPTION
reverts jruby/warbler#433

which wasn't a proper fix :disappointed: 

this reverts commit 160dc07