### PR TITLE
Added Gem.clear_paths to bundler.erb

### DIFF
--- a/lib/warbler/templates/bundler.erb
+++ b/lib/warbler/templates/bundler.erb
@@ -16,4 +16,6 @@ module Bundler
   end
 end
 
+Gem.clear_paths
+
 require 'bundler/shared_helpers'

--- a/spec/warbler/bundler_spec.rb
+++ b/spec/warbler/bundler_spec.rb
@@ -176,6 +176,7 @@ describe Warbler::Jar, "with Bundler" do
     run_in_directory "spec/sample_bundler"
 
     it "includes the bundler gem" do
+      bundle_install
       jar.apply(config)
       config.gems.detect{|k,v| k.name == 'bundler'}.should_not be nil
       file_list(/bundler-/).should_not be_empty


### PR DESCRIPTION
Tried deploying with Bundler 1.16.3 and it did not seem to resolve the issues with https://github.com/jruby/warbler/issues/432

Submitting the fix again (with proper method call this time) 