### PR TITLE
Include `gem_build_complete_path` in jar

### DIFF
--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -234,6 +234,11 @@ module Warbler
         next if config.gem_excludes && config.gem_excludes.any? {|rx| f =~ rx }
         @files[apply_pathmaps(config, File.join(spec.full_name, f), :gems)] = src
       end
+      if File.exist?(spec.gem_build_complete_path)
+        base_dir = Pathname.new(spec.base_dir)
+        gem_build_complete_path = Pathname.new(spec.gem_build_complete_path)
+        @files[File.join(config.relative_gem_path, gem_build_complete_path.relative_path_from(base_dir))] = spec.gem_build_complete_path
+      end
     end
 
     # Add all application directories and files to the archive.


### PR DESCRIPTION
`Gem::Specification#missing_extensions?` uses this file to determine if
a gem has properly completed building extensions.

I ran into a couple issues with gems getting bundled but then not being
available when running the jar because `missing_extensions?` was true.
This change got things working for me, though there may be a better way
to fix the issue.

Here's an example repo that shows the issue and fix: https://github.com/davishmcclurg/warbler-bug
I generated a Rails project under JRuby and added the thrift gem to break
the generated war file. The commits show how to reproduce.