### PR TITLE
Don't overwrite user-specified webserver.properties file

### DIFF
--- a/lib/warbler/web_server.rb
+++ b/lib/warbler/web_server.rb
@@ -103,7 +103,7 @@ module Warbler
 </Configure>
 CONFIG
 
-      jar.files["WEB-INF/webserver.properties"] = StringIO.new(<<-PROPS)
+      jar.files["WEB-INF/webserver.properties"] ||= StringIO.new(<<-PROPS)
 mainclass = org.eclipse.jetty.runner.Runner
 args = args0,args1,args2,args3,args4,args5,args6
 props = jetty.home

--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -1010,6 +1010,18 @@ describe Warbler::Jar do
       jar.contents('WEB-INF/myserver-web.xml').should =~ /web-app.*production/
     end
 
+    it "does not overwrite user-specified webserver.properties file" do
+      File.open("webserver.properties", "w") do |f|
+        f << "foo"
+      end
+      use_config do |config|
+        config.webinf_files = FileList['webserver.properties']
+      end
+      jar.apply(config)
+      file_list(%r{WEB-INF/webserver\.properties}).should_not be_empty
+      jar.contents('WEB-INF/webserver.properties').should == 'foo'
+    end
+
     it "excludes test files in gems according to config.gem_excludes" do
       use_config do |config|
         config.gem_excludes += [/^(test|spec)\//]


### PR DESCRIPTION
Even though there is support for the system property `warbler.host` for setting which host Jetty listens on, I don't want to put the onus on the user to set this when they run the JAR file in the case that I want the server to always run on a certain host (like 127.0.0.1). However, warbler was overwriting the `webserver.properties` file (see https://github.com/jruby/warbler/issues/181#issuecomment-97979928) which made it impossible to specify a permanent change without manually extracting and replacing the `webserver.properties` file.

This pull request simply makes it so warbler won't overwrite a user-supplied `webserver.properties` file.