### PR TITLE
1.x: Avoid removing files not ended in .rb

### DIFF
--- a/lib/warbler/task.rb
+++ b/lib/warbler/task.rb
@@ -108,7 +108,9 @@ module Warbler
       task "compiled" do
         jar.compile(config)
         task @name do
-          rm_f config.compiled_ruby_files.map {|f| f.sub(/\.rb$/, '.class') }
+          extensions = config.compiled_ruby_files&.map { |f| File.extname(f) }&.uniq || ['.rb']
+          regex_extensions = extensions.map { |extension| extension.sub('.', '\.') }.join('|')
+          rm_f config.compiled_ruby_files.map {|f| f.sub(/#{regex_extensions}$/, '.class') }
         end
       end
     end

--- a/spec/warbler/task_spec.rb
+++ b/spec/warbler/task_spec.rb
@@ -18,6 +18,8 @@ describe Warbler::Task do
       config.gems = ["rake"]
       config.webserver = "test"
       config.webxml.jruby.max.runtimes = 5
+
+      config.compiled_ruby_files = FileList['**/*.rb', '**/.rake']
     end
   end
 
@@ -148,6 +150,12 @@ describe Warbler::Task do
     config.features << "compiled"
     silence { run_task "warble" }
     File.exist?('app/helpers/application_helper.class').should be false
+  end
+
+  it "should not delete another extensions but .class files after finishing the jar" do
+    config.features << "compiled"
+    silence { run_task "warble" }
+    File.exist?('lib/tasks/utils.rake').should be true
   end
 
   context "where symlinks are available" do


### PR DESCRIPTION
When the option `compiled_ruby_files` is personalized to use different extensions, for instance, `.rake` files. They are removed each time warble is called.

Problem was in `lib/warbler/task.rb` where every file not ended in `.rb` were being removed.