### PR TITLE
Fix bug with gem_excludes not being used on bundler gems

### DIFF
--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -108,10 +108,8 @@ module Warbler
             filenames = []
             gem_relative_path.each_filename { |f| filenames << f }
 
-            exclude_gems = true
             unless filenames.empty?
               full_gem_path = Pathname.new(::Bundler.install_path) + filenames.first
-              exclude_gems = false
             end
 
             if spec.groups.include?(:warbler_excluded)
@@ -122,7 +120,7 @@ module Warbler
 
             FileList[pattern].each do |src|
               f = Pathname.new(src).relative_path_from(full_gem_path).to_s
-              next if exclude_gems && config.gem_excludes && config.gem_excludes.any? {|rx| f =~ rx }
+              next if config.gem_excludes && config.gem_excludes.any? {|rx| f =~ rx }
               jar.files[apply_pathmaps(config, File.join(full_gem_path.basename, f), :git)] = src
             end
           end


### PR DESCRIPTION
This is an upstream commit authored by @stalbot.

Unclear why in the original code `exclude_gems` was set to false if any files were found in the Git gem. It caused the condition to check for `config.gem_excludes` to not trigger.

(Looks like gem_excludes will not work neither when _spec.source_ is ::Bundler::Source::Path)

Co-authored-by: Steven Talbot <steven@looker.com>