### PR TITLE
Rakefile: fix typo JRUBY_VERISON

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ task :default => :spec
 # use Mavenfile to define :jar task
 require 'maven/ruby/maven'
 mvn = Maven::Ruby::Maven.new
-if defined?(JRUBY_VERISON) && ! (JRUBY_VERSION =~ /^9.0/)
+if defined?(JRUBY_VERSION) && !JRUBY_VERSION.start_with?('9.0')
   mvn.inherit_jruby_version
 end
 


### PR DESCRIPTION
This PR fixes a typo in the misspelled constant `JRUBY_VERISON`.

(Also, instead of a regex (slightly off, not escaped the `.`), we use `String#start_with?`.)