### PR TITLE
Travis: Ensure the JRUBY_OPTS set is global

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ branches:
     - master
     - /-dev|-feature|-fix/
 env:
-  - JRUBY_OPTS="-J-Xmx896M"
+  global:
+    JRUBY_OPTS: "-J-Xmx896M"
 script: bundle exec rake $TASK
 matrix:
   include:


### PR DESCRIPTION
This PR configures environment variables in the Travis configuration using the `env.global` key.
 
"Global" as opposed to "matrix-controlling".