### PR TITLE
Travis: gem uninstall bundler, sans rvm prefix, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,5 @@ before_install:
   - gem update --system 2.6.14
   - gem --version
   - rvm @global do gem uninstall bundler -a -x -I || true
+  - gem uninstall bundler -a -x -I || true
   - gem install bundler -v '< 2'


### PR DESCRIPTION
This PR ~tries to get~ gets the build to green.

- Bundler 2.1.x is being used, as it has been activated, somehow.

## Background

Travis output when we have the problem:

<details>

```
$ rvm --version
rvm 1.29.7 (latest) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]

$ bundle --version
Bundler version 2.1.4

$ gem --version
2.6.14.1
(before_install.1)

3.17s$ git fetch --unshallow
(before_install.2)

24.81s$ gem update --system 2.6.14
(before_install.3)

5.22s$ gem --version

2.6.14 (before_install.4)

29.06s$ rvm @global do gem uninstall bundler -a -x -I || true
Removing bundle
Removing bundler

Successfully uninstalled bundler-2.1.4 (before_install.5)

10.72s$ gem install bundler -v '< 2'

44.03s$ bundle install --jobs=3 --retry=3
Fetching gem metadata from https://rubygems.org/...........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies....

Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    jbundler (~> 0.9) java was resolved to 0.9.3, which depends on
      bundler (~> 1.5) java
  Current Bundler version:
    bundler (2.1.4)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
Could not find gem 'bundler (~> 1.5)', which is required by gem 'jbundler (~>
0.9)', in any of the sources.
```

</details>

## Solution

My solution was to `gem uninstall bundler` in the "normal space", too, as perhaps rvm had created a named gemset of some other kind for us, and "entered" that gemset.

Anyway, it seems to continue the installation.