### PR TITLE
Rakefile: Fix a typo bug JRUBY_VERISON -> JRUBY_VERSION

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ task :default => :spec
 # use Mavenfile to define :jar task
 require 'maven/ruby/maven'
 mvn = Maven::Ruby::Maven.new
-if defined?(JRUBY_VERISON) && ! (JRUBY_VERSION =~ /^9.0/)
+if defined?(JRUBY_VERSION) && ! (JRUBY_VERSION =~ /^9.0/)
   mvn.inherit_jruby_version
 end
 


### PR DESCRIPTION
This PR fixes a typo which stopped Maven tasks from getting the configured value of "jruby version".

It _looks_ like this would allow Maven to have the correct JRuby version configured.

