### PR TITLE
Spec: Configure a git default branch name, silences warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,7 @@ module ExampleGroupHelpers
         `git init`
         `git config user.email "warbler-test@null.com"`
         `git config user.name  "Warbler Test"`
+        `git config --global init.defaultBranch main`
 
         # `bundle install --local`
         `git add .`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,10 +87,9 @@ module ExampleGroupHelpers
   def create_git_gem(gem_name)
     before do
       @gem_dir = generate_gem(gem_name) do |gem_dir|
-        `git init`
+        `git init -b master`
         `git config user.email "warbler-test@null.com"`
         `git config user.name  "Warbler Test"`
-        `git config --global init.defaultBranch main`
 
         # `bundle install --local`
         `git add .`


### PR DESCRIPTION
This avoids long output like:

    hint: Using 'master' as the name for the initial branch. This default branch name
    hint: is subject to change. To configure the initial branch name to use in all
    hint: of your new repositories, which will suppress this warning, call:
    hint:
    hint: 	git config --global init.defaultBranch <name>
    hint:
    hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
    hint: 'development'. The just-created branch can be renamed via this command:
    hint:
    hint: 	git branch -m <name>