### PR TITLE
Drop support for old rake versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,6 @@ jobs:
 
           - java-version: 8
             ruby-version: jruby-9.2.18.0
-            rake-version: ~>10.1
-            task: ''
-
-          - java-version: 8
-            ruby-version: jruby-9.2.18.0
-            rake-version: ~>11.2
-            task: ''
-
-          - java-version: 8
-            ruby-version: jruby-9.2.18.0
             rake-version: ~>12.3
             task: ''
 

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -28,7 +28,7 @@ bundle up all of your application files for deployment to a Java environment.}
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_runtime_dependency 'rake', ['>= 10.1.0']
+  gem.add_runtime_dependency 'rake', ['>= 12.3.3']
   gem.add_runtime_dependency 'jruby-jars', ['>= 9.0.0']
   gem.add_runtime_dependency 'jruby-rack', ['>= 1.1.1', '< 1.3']
   gem.add_runtime_dependency 'rubyzip', '>= 1.0.0'


### PR DESCRIPTION
As showed in #501, old rake versions seem to be causing some issues. I propose to forget about them. Upgrading rake, even major versions, is straightforward.