### PR TITLE
Drop rake 12 support too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         java-version: [8, 15]
         ruby-version: [jruby-9.2.18.0, jruby-head]
-        rake-version: ['']
         task: ['']
 
         include:
@@ -30,16 +29,6 @@ jobs:
           - java-version: 15
             ruby-version: jruby-9.2.18.0
             task: integration
-
-          - java-version: 8
-            ruby-version: jruby-9.2.18.0
-            rake-version: ~>12.3
-            task: ''
-
-          - java-version: 15
-            ruby-version: jruby-9.2.18.0
-            rake-version: ~>12.3
-            task: ''
 
       fail-fast: false
 
@@ -64,17 +53,11 @@ jobs:
 
       - name: Install dependencies
         run: bundle install --jobs=3 --retry=3
-        env:
-          RAKE_VERSION: ${{ matrix.rake-version }}
 
       - name: Run tests
         run: bundle exec rake ${{ matrix.TASK }}
-        env:
-          RAKE_VERSION: ${{ matrix.rake-version }}
         if: matrix.ruby-version !=  'jruby-head'
 
       - name: Run tests
         run: bundle exec rake ${{ matrix.TASK }} || exit 0
-        env:
-          RAKE_VERSION: ${{ matrix.rake-version }}
         if: matrix.ruby-version ==  'jruby-head'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,7 @@ jobs:
       matrix:
         java-version: [8, 15]
         ruby-version: [jruby-9.2.18.0, jruby-head]
-        task: ['']
-
-        include:
-          - java-version: 8
-            ruby-version: jruby-9.2.18.0
-            task: integration
-
-          - java-version: 15
-            ruby-version: jruby-9.2.18.0
-            task: integration
+        task: ['', integration]
 
       fail-fast: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,6 @@ gemspec
 rubyzip_version = ENV['RUBYZIP_VERSION']
 gem 'rubyzip', rubyzip_version if rubyzip_version && !rubyzip_version.empty?
 
-rake_version = ENV['RAKE_VERSION']
-gem 'rake', rake_version, :require => nil if rake_version && !rake_version.empty?
-
 group :development, :test do
   gem 'rdoc', ['>= 3.10', '< 4.3'], :require => nil
 end

--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,6 @@ end
 require 'rake/clean'
 CLEAN << "pkg" << "doc" << Dir['integration/**/target']
 
-unless Rake::Application.method_defined? :last_comment
-  Rake::Application.module_eval do
-    alias_method :last_comment, :last_description
-  end
-end # Rake 11 compatibility (due rspec/core/rake_task < 3.0)
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = ['--color', "--format documentation"]

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -28,7 +28,7 @@ bundle up all of your application files for deployment to a Java environment.}
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_runtime_dependency 'rake', ['>= 12.3.3']
+  gem.add_runtime_dependency 'rake', ['>= 13.0.3']
   gem.add_runtime_dependency 'jruby-jars', ['>= 9.0.0']
   gem.add_runtime_dependency 'jruby-rack', ['>= 1.1.1', '< 1.3']
   gem.add_runtime_dependency 'rubyzip', '>= 1.0.0'


### PR DESCRIPTION
In #503 we dropped support for old rake versions, but left rake 12 support in there. I think it's better to focus only on the last mayor.