### PR TITLE
Fix helper class used for config.webxml values

### DIFF
--- a/lib/warbler/traits/war.rb
+++ b/lib/warbler/traits/war.rb
@@ -182,33 +182,13 @@ module Warbler
         end
 
         def [](key)
-          new_ostruct_member(key)
+          new_ostruct_member!(key)
           send(key)
         end
 
         def []=(key, value)
-          new_ostruct_member(key)
+          new_ostruct_member!(key)
           send("#{key}=", value)
-        end
-
-        def method_missing(mid, *args)
-          len = args.length
-          if mname = mid[/.*(?==\z)/m]
-            if len != 1
-              raise ArgumentError, "wrong number of arguments (#{len} for 1)", caller(1)
-            end
-            modifiable[new_ostruct_member(mname)] = args[0]
-          elsif len == 0
-            @table[mid]
-          else
-            err = NoMethodError.new "undefined method `#{mid}' for #{self}", mid, args
-            err.set_backtrace caller(1)
-            raise err
-          end
-        end
-
-        def respond_to_missing?(mid, include_private = false)
-          @table.key?(mid.to_s.chomp('=').to_sym) || super
         end
 
         def servlet_filter; @servlet_filter ||= 'org.jruby.rack.RackFilter' end
@@ -258,6 +238,28 @@ module Warbler
 
         def to_s
           "No value for '#@key' found"
+        end
+
+        private
+
+        def method_missing(mid, *args)
+          len = args.length
+          if mname = mid[/.*(?==\z)/m]
+            if len != 1
+              raise ArgumentError, "wrong number of arguments (#{len} for 1)", caller(1)
+            end
+            modifiable[new_ostruct_member!(mname)] = args[0]
+          elsif len == 0
+            @table[mid]
+          else
+            err = NoMethodError.new "undefined method `#{mid}' for #{self}", mid, args
+            err.set_backtrace caller(1)
+            raise err
+          end
+        end
+
+        def respond_to_missing?(mid, include_private = false)
+          @table.key?(mid.to_s.chomp('=').to_sym) || super
         end
       end
     end


### PR DESCRIPTION
This fixes the issue reported in theJRuby repo:

https://github.com/jruby/jruby/issues/7160

Basically the issue was caused due 2 changes in the ostruct repo:

change 1:
```
commit d39c4e3feab2852f45cff791cf8cd684960c07a1
Refs:
Author:     nobu <nobu@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
AuthorDate: Mon Jan 5 01:57:26 2015 +0000
Commit:     nobu <nobu@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
CommitDate: Mon Jan 5 01:57:26 2015 +0000

    ostruct.rb: append suffixes to protected methods

    * lib/ostruct.rb (modifiable?, new_ostruct_member!, table!):
      append suffixes to protected methods so that they will not clash
      with assigned members.  [Fix GH-806]

    git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@49145 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
```
change 2:
```
commit 6dbc902092249ae2c75546fd121ba7618d3645c7
Refs: v0.1.0-33-g6dbc902
Author:     Marc-Andre Lafortune <github@marc-andre.ca>
AuthorDate: Mon Sep 14 14:06:49 2020 -0400
Commit:     Marc-Andre Lafortune <github@marc-andre.ca>
CommitDate: Mon Sep 14 16:13:45 2020 -0400

    method_missing is private
```
