### PR TITLE
CI: Install a RubyGems 3.2.x for jruby-head, and ensure a Bundler 1.17.3 is available and used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
       # rubygems 2.7.11 is not supported on Ruby 3.1.0 (jruby-head).
       # The oldest version supported by this ruby is 3.2.3.
       - name: Install fixed rubygems version
-        run: gem update --system 3.2.11
+        run: gem update --system 3.2.11 && gem install bundler:1.17.3
         if: matrix.ruby-version ==  'jruby-head'
 
       - name: Install dependencies
-        run: bundle install --jobs=3 --retry=3
+        run: bundle _1.17.3_ install --jobs=3 --retry=3
 
       - name: Run tests
         run: bundle exec rake ${{ matrix.TASK }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
 
       - name: Install fixed rubygems version
         run: gem update --system 2.7.11
+        if: matrix.ruby-version !=  'jruby-head'
+
+      # rubygems 2.7.11 is not supported on Ruby 3.1.0 (jruby-head).
+      # The oldest version supported by this ruby is 3.2.3.
+      - name: Install fixed rubygems version
+        run: gem update --system 3.2.11
+        if: matrix.ruby-version ==  'jruby-head'
 
       - name: Install dependencies
         run: bundle install --jobs=3 --retry=3


### PR DESCRIPTION
In order to dance around issues, I picked the very latest release of RubyGems to fix on, for jruby-head.

Also: Separately install Bundler 1.17.3 for that version of Ruby, and point out exactly which Bundler to use when running `bundle install`. (Perhaps this last little thing can be omitted, I don't know, but – we are now green again.)