### PR TITLE
Fix for webxmlopenstruct (on JRuby 9.3)

### DIFF
--- a/lib/warbler/traits/war.rb
+++ b/lib/warbler/traits/war.rb
@@ -181,16 +181,6 @@ module Warbler
           @servlet_filter_async = nil # true/false
         end
 
-        def [](key)
-          new_ostruct_member!(key)
-          send(key)
-        end
-
-        def []=(key, value)
-          new_ostruct_member!(key)
-          send("#{key}=", value)
-        end
-
         def servlet_filter; @servlet_filter ||= 'org.jruby.rack.RackFilter' end
         attr_writer :servlet_filter
 
@@ -248,7 +238,7 @@ module Warbler
             if len != 1
               raise ArgumentError, "wrong number of arguments (#{len} for 1)", caller(1)
             end
-            modifiable[new_ostruct_member!(mname)] = args[0]
+            self[mname] = args[0]
           elsif len == 0
             @table[mid]
           else

--- a/lib/warbler/traits/war.rb
+++ b/lib/warbler/traits/war.rb
@@ -176,7 +176,10 @@ module Warbler
 
         def initialize(key = 'webxml')
           @key = key
-          @table = Hash.new { |h, k| h[k] = WebxmlOpenStruct.new(k) }
+          @table = Hash.new { |h, k|
+            new_ostruct_member!(k)
+            h[k] = WebxmlOpenStruct.new(k)
+          }
 
           @servlet_filter_async = nil # true/false
         end


### PR DESCRIPTION
On JRuby 9.3 the fix from #513 does not work, because the `modifiable` method has disappeared.

On JRuby 9.2 replacing `modifiable[new_ostruct_member!(mname)]=` with `self[mname]=` is not a problem as the existing implementation of `#[]=` takes care of both checking that it's still modifiable and calling `new_ostruct_member!`.