### PR TITLE
Fix warbler build, issue due rubygems changes

### DIFF
--- a/Mavenfile
+++ b/Mavenfile
@@ -5,9 +5,9 @@
 gemspec( :jar => 'warbler_jar.jar',
          :source => 'ext' )
 
-properties( 'jruby.plugins.version' => '1.1.5',
-            'jruby.version' => '9.1.8.0',
-            'jetty.version' => '9.2.10.v20150310' )
+properties( 'jruby.plugins.version' => '2.0.1',
+            'jruby.version' => '9.2.21.0',
+            'jetty.version' => '9.4.31.v20200723' )
 
 # dependencies needed for compilation
 scope :provided do


### PR DESCRIPTION
This pull request fixes building warbler, issue reported in https://github.com/jruby/warbler/issues/522

JRuby 9.2.21.0
```
Downloading: mavengem:https://rubygems.org/org/jruby/jruby-complete/9.2.21.0/jruby-complete-9.2.21.0.jar
Downloading: https://repo.maven.apache.org/maven2/org/jruby/jruby-complete/9.2.21.0/jruby-complete-9.2.21.0.jar
Downloaded: https://repo.maven.apache.org/maven2/org/jruby/jruby-complete/9.2.21.0/jruby-complete-9.2.21.0.jar (28162 KB at 1876.0 KB/sec)
[INFO] ERROR:  While executing gem ... (OptionParser::InvalidOption)
[INFO]     invalid option: --no-rdoc
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 04:31 min
[INFO] Finished at: 2022-09-21T06:16:45+10:00
[INFO] Final Memory: 63M/260M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal de.saumya.mojo:gem-maven-plugin:1.1.5:initialize (default-initialize) on project warbler: Execution default-initialize of goal de.saumya.mojo:gem-maven-plugin:1.1.5:initialize failed: Java returned: 1 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```
JRuby 9.3.8.0
```
Downloaded: https://repo.maven.apache.org/maven2/org/jruby/jruby-base/9.3.8.0/jruby-base-9.3.8.0.jar (8307 KB at 609.5 KB/sec)
Downloaded: https://repo.maven.apache.org/maven2/org/jruby/jruby-stdlib/9.3.8.0/jruby-stdlib-9.3.8.0.jar (13174 KB at 774.2 KB/sec)
[INFO] 
[INFO] --- gem-maven-plugin:1.1.5:initialize (default-initialize) @ warbler ---
Downloading: mavengem:https://rubygems.org/org/jruby/jruby-complete/9.3.8.0/jruby-complete-9.3.8.0.jar
Downloading: https://repo.maven.apache.org/maven2/org/jruby/jruby-complete/9.3.8.0/jruby-complete-9.3.8.0.jar
Downloaded: https://repo.maven.apache.org/maven2/org/jruby/jruby-complete/9.3.8.0/jruby-complete-9.3.8.0.jar (28739 KB at 2962.5 KB/sec)
[INFO] ERROR:  While executing gem ... (OptionParser::InvalidOption)
[INFO]     invalid option: --no-rdoc
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 45.787 s
[INFO] Finished at: 2022-09-21T06:31:43+10:00
[INFO] Final Memory: 57M/228M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal de.saumya.mojo:gem-maven-plugin:1.1.5:initialize (default-initialize) on project warbler: Execution default-initialize of goal de.saumya.mojo:gem-maven-plugin:1.1.5:initialize failed: Java returned: 1 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```
The relevant fixes were applied to [jruby-maven-plugins](https://github.com/torquebox/jruby-maven-plugins) version `2.0.1`




The failure is because rubygems removed --ri and --rdoc in version 3.0.1

More info at:
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

