### PR TITLE
Fix war file path as argument for jetty runner

### DIFF
--- a/ext/JarMain.java
+++ b/ext/JarMain.java
@@ -51,9 +51,7 @@ public class JarMain implements Runnable {
             throw new RuntimeException(e);
         }
 
-        file = new File(uri.getPath());
-
-        archive = file.getAbsolutePath();
+        archive = new File(uri.getPath()).getAbsolutePath();
 
         Runtime.getRuntime().addShutdownHook(new Thread(this));
     }

--- a/ext/JarMain.java
+++ b/ext/JarMain.java
@@ -40,13 +40,20 @@ public class JarMain implements Runnable {
     JarMain(String[] args) {
         this.args = args;
         URL mainClass = getClass().getResource(MAIN);
+        URI uri;
+        File file;
+
         try {
             this.path = mainClass.toURI().getSchemeSpecificPart();
+            uri = new URI(this.path.replace("!" + MAIN, ""));
         }
         catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
-        archive = this.path.replace("!" + MAIN, "").replace("file:", "");
+
+        file = new File(uri.getPath());
+
+        archive = file.getAbsolutePath();
 
         Runtime.getRuntime().addShutdownHook(new Thread(this));
     }


### PR DESCRIPTION
This fix the war file path that is given to the embedded Jetty runner.

Before this change:
(only works in older jetty version older than `9.4.32.v20200930`)
```
invoking webserver with:
[--host, 0.0.0.0, --port, 8080, --config, jar:file:/D:/workbench/samson.war!/WEB-INF/webserver.xml, /D:/workbench/samson.war]
```

After this change:
(works for newer jetty versions starting with `9.4.32.v20200930`, includes jetty 10.x) 
```
invoking webserver with:
[--host, 0.0.0.0, --port, 8080, --config, jar:file:/D:/workbench/samson.war!/WEB-INF/webserver.xml, D:\workbench\samson.war]
```

