### PR TITLE
Avoid rspec deprecation warning

### DIFF
--- a/spec/warbler/jar_spec.rb
+++ b/spec/warbler/jar_spec.rb
@@ -560,10 +560,10 @@ describe Warbler::Jar do
       use_config do |config|
         config.gems = ["nonexistent-gem"]
       end
-      expect(lambda {
+      expect {
         Warbler::Task.new "warble", config
         jar.apply(config)
-      }).to raise_error(Gem::MissingSpecError)
+      }.to raise_error(Gem::MissingSpecError)
     end
 
     it "allows specification of dependency by Gem::Dependency" do


### PR DESCRIPTION
Saw a failed test, which ended with a failure message.

The deprecation warning was:

    The implicit block expectation syntax is deprecated, you should pass a
    block rather than an argument to `expect` to use the provided block
    expectation matcher or the matcher must implement
    `supports_value_expectations?`. e.g  `expect { value }.to raise
    Gem::MissingSpecError` not `expect(value).to raise
    Gem::MissingSpecError`

This PR changes the expectation to follow RSpec's recording.

---

Incidentally, the other error was this:

> 
> Failures:
> 
>   1) Warbler::Jar with Bundler in a war project detects a Gemfile and process only its gems
>      Failure/Error: ruby "-I#{Warbler::WARBLER_HOME}/lib", File.join(@orig_dir, 'spec/drb_helper.rb')
> 
>      Errno::EINTR:
>        Interrupted system call - Another thread waited the process started by system().
>      \# ./spec/spec_helper.rb:132:in `block in drb'