### PR TITLE
Resolve test failure from bundler 2.2.24+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,13 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8, 15]
-        ruby-version: [jruby-9.2.18.0, jruby-head]
+        java-version: [8, 11, 15]
+        ruby-version: [jruby-9.2.21.0, jruby-9.3.13.0, jruby-9.4.5.0, jruby-head]
+        bundler-version: [1.17.3, 2.3.26, 2.4.21]
         task: ['', integration]
+        exclude:
+          - ruby-version: jruby-9.2.21.0
+            bundler-version: 2.4.21
 
       fail-fast: false
 
@@ -37,20 +41,17 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 1.17.3
 
-      - name: Install fixed rubygems version for non-jruby-head
-        run: gem update --system 2.7.11
-        if: ${{ matrix.ruby-version != 'jruby-head' }}
+      - name: Install bundler ${{ matrix.bundler-version }}
+        run: gem install bundler:${{ matrix.bundler-version }}
+        if: ${{ matrix.ruby-version == 'jruby-9.2.21.0' }}
 
-      # rubygems 2.7.11 is not supported on Ruby 3.1.0 (jruby-head).
-      # The oldest version supported by this ruby is 3.3.3.
-      - name: Install fixed rubygems version for jruby-head
-        run: gem update --system 3.3.3 && gem install bundler:1.17.3
-        if: ${{ matrix.ruby-version == 'jruby-head' }}
+      - name: Install latest rubygems version with bundler ${{ matrix.bundler-version }}
+        run: gem update --system && gem install bundler:${{ matrix.bundler-version }}
+        if: ${{ matrix.ruby-version != 'jruby-9.2.21.0' }}
 
       - name: Install dependencies
-        run: bundle _1.17.3_ install --jobs=3 --retry=3
+        run: bundle _${{ matrix.bundler-version }}_ install --jobs=3 --retry=3
 
       - name: Run tests
         run: bundle exec rake ${{ matrix.TASK }}

--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -143,7 +143,8 @@ module Warbler
         bundle_without = config.bundle_without.map { |s| s.to_sym }
         definition = ::Bundler.definition
         all = definition.specs.to_a
-        requested = definition.specs_for(definition.groups - bundle_without).to_a
+        requested_groups = definition.groups - bundle_without
+        requested = requested_groups.empty? ? [] : definition.specs_for(requested_groups).to_a
         excluded_git_specs = (all - requested).select { |spec| ::Bundler::Source::Git === spec.source }
         excluded_git_specs.each { |spec| spec.groups << :warbler_excluded }
         requested + excluded_git_specs

--- a/spec/warbler/bundler_spec.rb
+++ b/spec/warbler/bundler_spec.rb
@@ -22,7 +22,7 @@ describe Warbler::Jar, "with Bundler" do
   end
 
   def bundle_install(*args)
-    `cd #{Dir.pwd} && #{RUBY_EXE} -S bundle install #{args.join(' ')}`
+    `cd #{Dir.pwd} && #{RUBY_EXE} -S bundle _#{::Bundler::VERSION}_ install #{args.join(' ')}`
   end
 
   let(:config) { drbclient.config(@extra_config) }

--- a/spec/warbler/web_server_spec.rb
+++ b/spec/warbler/web_server_spec.rb
@@ -8,7 +8,7 @@ end
 
 describe Warbler::WebServer::Artifact do
 
-  @@_env = ENV.dup
+  @@_env = ENV.to_h
 
   after(:all) { ENV.clear; ENV.update @@_env }
 

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -29,6 +29,7 @@ bundle up all of your application files for deployment to a Java environment.}
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_runtime_dependency 'rake', ['>= 13.0.3']
+  gem.add_runtime_dependency 'rexml', '~> 3.0'
   gem.add_runtime_dependency 'jruby-jars', ['>= 9.0.0']
   gem.add_runtime_dependency 'jruby-rack', ['>= 1.1.1', '< 1.3']
   gem.add_runtime_dependency 'rubyzip', '>= 1.0.0'


### PR DESCRIPTION
Bundler v2.2.24 changed the behaviour of `Bundler::Definition#specs_for` when the requested groups are empty from returning nothing to everything.