### PR TITLE
 Fixes for safe_level, trim_mode argument of ERB.new is deprecated warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gem 'rubyzip', rubyzip_version if rubyzip_version && !rubyzip_version.empty?
 
 group :development, :test do
   gem 'rdoc', ['>= 3.10', '< 4.3'], :require => nil
+  gem 'dotenv'
 end

--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -285,7 +285,7 @@ module Warbler
 
     def expand_erb(file, config)
       require 'erb'
-      erb = ERB.new(File.read(file), nil, '-')
+      erb = ERB.new(File.read(file), trim_mode: '-')
       StringIO.new(erb.result(erb_binding(config)))
     end
 

--- a/spec/warbler/web_server_spec.rb
+++ b/spec/warbler/web_server_spec.rb
@@ -1,4 +1,6 @@
 require File.expand_path('../../spec_helper', __FILE__)
+require 'dotenv'
+
 
 class Warbler::WebServer::Artifact
   def self.reset_local_repository
@@ -8,9 +10,19 @@ end
 
 describe Warbler::WebServer::Artifact do
 
-  @@_env = ENV.to_h
+  #@@_env = ENV.to_h
+  Dotenv.load
+ 
+  before(:all) do
+    @original_env = ENV.to_h
+  end
 
-  after(:all) { ENV.clear; ENV.update @@_env }
+  after(:all) do
+    ENV.clear
+    @original_env.each { |k, v| ENV[k] = v }
+  end
+
+  # after(:all) { ENV.clear; ENV.update @@_env }
 
   before do
     Warbler::WebServer::Artifact.reset_local_repository


### PR DESCRIPTION
/workspaces/warbler/lib/warbler/jar.rb:288: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/workspaces/warbler/lib/warbler/jar.rb:288: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.