### PR TITLE
bundler trait infinite loop fix

### DIFF
--- a/lib/warbler/traits/bundler.rb
+++ b/lib/warbler/traits/bundler.rb
@@ -45,7 +45,7 @@ module Warbler
             while ! full_gem_path.join('bundler.gemspec').exist?
               full_gem_path = full_gem_path.dirname
               # if at top of the path, meaning we cannot find bundler.gemspec, abort.
-              if full_gem_path.to_s =~ /^[\.\/]$/
+              if full_gem_path.root?
                 warn("Unable to detect bundler spec under '#{spec.full_gem_path}'' and its sub-dirs")
                 exit
               end


### PR DESCRIPTION
This is a fix (#555) for an infinite loop that occurs on Windows during a warble build when it cannot find the bundler.gemspec file