### PR TITLE
Try to fix Gem.paths

### DIFF
--- a/lib/warbler/templates/bundler.erb
+++ b/lib/warbler/templates/bundler.erb
@@ -16,4 +16,5 @@ module Bundler
   end
 end
 
+Gem.paths = ENV
 require 'bundler/shared_helpers'


### PR DESCRIPTION
See jruby/warbler#539 and jruby/warbler#537.

This fix is based on comments in the respective tickets. Since the entire file appears to be a hack or monkey patch, I’m not sure whether this is the “correct” solution. However, it works for us with JRuby 9.4, the current master of Warbler, and Bundler 2.6.3, running on Tomcat 9 under macOS and Windows.