### PR TITLE
Forward maven exit code to rake tasks to fix false positives on CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,17 +36,20 @@ end
 
 desc 'compile java sources and build jar'
 task :jar do
-  mvn.prepare_package
+  success = mvn.prepare_package
+  exit(1) unless success
 end
 
 desc 'run some integration test'
 task :integration do
-  mvn.verify
+  success = mvn.verify
+  exit(1) unless success
 end
 
 desc 'generate the pom.xml from the Mavenfile'
 task :pom do
-  mvn.validate('-Dpolyglot.dump.pom=pom.xml')
+  success = mvn.validate('-Dpolyglot.dump.pom=pom.xml')
+  exit(1) unless success
 end
 
 # Make sure jar gets compiled before the gem is built


### PR DESCRIPTION
This PR ensures that Maven’s exit code is propagated to the Rake tasks, fixing a problem where CI falsely reports success despite failing integration tests (fixes #563). Rake tasks that invoke Maven currently always return `exit 0`.

See: https://github.com/jruby/warbler/actions/runs/15866068938/job/44733092626#step:7:1212
