### PR TITLE
Correct GitHub Actions CI branch filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - master
-      - /-dev|-feature|-fix/
+      - '*-dev'
+      - '*-feature'
+      - '*-fix'
 
   pull_request:
 
@@ -53,4 +55,4 @@ jobs:
         run: bundle install --jobs=3 --retry=3
 
       - name: Run tests
-        run: bundle exec rake ${{ matrix.TASK }}
+        run: bundle exec rake ${{ matrix.task }}


### PR DESCRIPTION
This PR updates the GitHub Actions workflow configuration to ensure that push triggers use proper branch patterns. The previous configuration used a regex-like syntax (/-dev|-feature|-fix/), which is not supported by GitHub Actions. This has been replaced with glob patterns.

Fixes also a case sensitivity issue by changing `matrix.TASK` to  `matrix.task`.