### PR TITLE
Use newer keyword argument rubyzip 3.0 API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source "https://rubygems.org/"
 
 gemspec
 
-rubyzip_version = ENV['RUBYZIP_VERSION']
-gem 'rubyzip', rubyzip_version if rubyzip_version && !rubyzip_version.empty?
-
 # override default maven-tools used by bundler
 gem 'maven-tools', '1.2.3'
 

--- a/lib/warbler/zip_support.rb
+++ b/lib/warbler/zip_support.rb
@@ -3,7 +3,7 @@ require 'zip'
 module Warbler
   class ZipSupport
     def self.create(filename, &blk)
-      Zip::File.open(filename, Zip::File::CREATE, &blk)
+      ::Zip::File.open(filename, create: true, &blk)
     end
 
     def self.open(filename, &blk)

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -32,7 +32,7 @@ bundle up all of your application files for deployment to a Java environment.}
   gem.add_runtime_dependency 'rexml', '~> 3.0'
   gem.add_runtime_dependency 'jruby-jars', ['>= 9.0.0']
   gem.add_runtime_dependency 'jruby-rack', ['>= 1.1.1', '< 1.3']
-  gem.add_runtime_dependency 'rubyzip', '>= 1.0.0'
+  gem.add_runtime_dependency 'rubyzip', '>= 3.0.0'
   gem.add_runtime_dependency 'ostruct', '0.6.2'
   gem.add_development_dependency 'jbundler', '0.9.5'
   gem.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
After #567 we got a newer rubyzip, which has a keyword argument API. This PR gets to green tests.

- use kwargs API
- require rubyzip 3.0+ and
- drop support for the ENV variable for rubyzip version in the Gemfile (no longer used in our CI)

Resource: [rubyzip's CHANGELOG](https://github.com/rubyzip/rubyzip/blob/main/Changelog.md). rubyzip 3.0.0 began requiring Ruby 3.0+. The CHANGELOG for 3.0.0: "Use named parameters for optional arguments in the public API."

Fixes #570 