### PR TITLE
Fix gem path resolution for `JRuby 9.4+` and `Rails 7+`

### DIFF
--- a/lib/warbler/templates/bundler.erb
+++ b/lib/warbler/templates/bundler.erb
@@ -4,12 +4,7 @@ ENV['BUNDLE_FROZEN'] = '1'
 <% end -%>
 
 # Fix for JRuby 9.4+ and Rails 7+ gem path resolution
-puts "helooo"
 if defined?(Gem) && Gem.respond_to?(:paths=)
-  puts "setting gem paths"
-  puts ENV
-  puts Gem.paths
-  
   Gem.paths = {
     'GEM_HOME' => ENV['GEM_HOME'],
     'GEM_PATH' => ENV['GEM_PATH']

--- a/lib/warbler/templates/bundler.erb
+++ b/lib/warbler/templates/bundler.erb
@@ -4,7 +4,12 @@ ENV['BUNDLE_FROZEN'] = '1'
 <% end -%>
 
 # Fix for JRuby 9.4+ and Rails 7+ gem path resolution
+puts "helooo"
 if defined?(Gem) && Gem.respond_to?(:paths=)
+  puts "setting gem paths"
+  puts ENV
+  puts Gem.paths
+  
   Gem.paths = {
     'GEM_HOME' => ENV['GEM_HOME'],
     'GEM_PATH' => ENV['GEM_PATH']

--- a/lib/warbler/templates/bundler.erb
+++ b/lib/warbler/templates/bundler.erb
@@ -7,7 +7,7 @@ ENV['BUNDLE_FROZEN'] = '1'
 if defined?(Gem) && Gem.respond_to?(:paths=)
   Gem.paths = {
     'GEM_HOME' => ENV['GEM_HOME'],
-    'GEM_PATH' => ENV['GEM_PATH']
+    'GEM_PATH' => nil
   }
 end
 

--- a/lib/warbler/templates/bundler.erb
+++ b/lib/warbler/templates/bundler.erb
@@ -3,6 +3,14 @@ ENV['BUNDLE_WITHOUT'] = '<%= config.bundle_without.join(':') %>'
 ENV['BUNDLE_FROZEN'] = '1'
 <% end -%>
 
+# Fix for JRuby 9.4+ and Rails 7+ gem path resolution
+if defined?(Gem) && Gem.respond_to?(:paths=)
+  Gem.paths = {
+    'GEM_HOME' => ENV['GEM_HOME'],
+    'GEM_PATH' => ENV['GEM_PATH']
+  }
+end
+
 module Bundler
   module Patch
     def clean_load_path


### PR DESCRIPTION

1. Consistency with war.erb template behavior
2. Isolation - only uses gems packaged in the WAR
3. No system gem conflicts - prevents loading host system gems
4. Self-contained deployment - WAR file is completely portable