### PR TITLE
Proper JRuby at runtime requirement

### DIFF
--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -30,7 +30,7 @@ bundle up all of your application files for deployment to a Java environment.}
 
   gem.add_runtime_dependency 'rake', ['~> 13.0', '>= 13.0.3']
   gem.add_runtime_dependency 'rexml', '~> 3.0'
-  gem.add_runtime_dependency 'jruby-jars', ['>= 9.0.0']
+  gem.add_runtime_dependency 'jruby-jars', ['>= 9.4', '< 10.1']
   gem.add_runtime_dependency 'jruby-rack', ['>= 1.1.1', '< 1.3']
   gem.add_runtime_dependency 'rubyzip', '>= 3.0.0'
   gem.add_runtime_dependency 'ostruct', '0.6.2'


### PR DESCRIPTION
This will effectively declare the proper JRuby version at runtime.

Building and running Ruby version might be completely different with Warbler, that's why https://github.com/jruby/warbler/commit/b7b47b76b8e015a5cacf3cfbbf5b90fa3eea90d1 won't have the proper effect.