### PR TITLE
build: add dependabot config to help us manage dependency versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions-deps:
+        patterns: [ "*" ]
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: maven
+    directories:
+      - "/integration/*"
+    schedule:
+      interval: weekly
+    groups:
+      maven-test-deps:
+        patterns: [ "*" ]
+    commit-message:
+      prefix: "test(deps): "
+    ignore:
+      - dependency-name: "rubygems:*" # Versions only specified for local convenience
+      - dependency-name: "org.eclipse.jetty:*"
+        update-types: [ "version-update:semver-major" ] # Major update requires dropping Java < 11 compat
+      - dependency-name: "org.junit.jupiter:*"
+        update-types: [ "version-update:semver-major" ] # Major update requires dropping Java < 17 compat
+  - package-ecosystem: bundler
+    directories:
+      - "/"
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-type: all
+    groups:
+      ruby-deps:
+        dependency-type: "production"
+      ruby-dev-deps:
+        dependency-type: "development"
+    commit-message:
+      prefix: "build(deps): "
+      prefix-development: "chore(deps): "
+    ignore:
+      - dependency-name: "rails"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "rack"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,11 @@ gemspec
 # override default maven-tools used by bundler
 gem 'maven-tools', '1.2.3'
 
-
 group :development, :test do
-  gem 'rdoc', ['>= 3.10', '< 7'], :require => nil
+  gem 'rdoc', '~> 6.0', :require => nil
 
-  # force jruby-jars to use current JRuby version for testing
-  gem 'jruby-jars', '~> ' + JRUBY_VERSION.split('.')[0..1].join('.')
+  if defined?(JRUBY_VERSION)
+    # force jruby-jars to use current JRuby version for testing
+    gem 'jruby-jars', '~> ' + JRUBY_VERSION.split('.')[0..2].join('.')
+  end
 end

--- a/integration/rails7_test/src/main/ruby/Gemfile
+++ b/integration/rails7_test/src/main/ruby/Gemfile
@@ -3,4 +3,6 @@ source 'https://rubygems.org'
 gem 'rails', '~> 7.2.0'
 gem 'rack', '~> 2.2.19'
 
-gem 'activerecord-jdbcsqlite3-adapter', '~> 72.1'
+platform :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 72.1'
+end

--- a/spec/rails7_stub/Gemfile
+++ b/spec/rails7_stub/Gemfile
@@ -2,4 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 7.2.0'
 
-gem 'activerecord-jdbcpostgresql-adapter', '~> 72.1'
+platform :jruby do
+  gem 'activerecord-jdbcpostgresql-adapter', '~> 72.1'
+end

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -33,9 +33,10 @@ bundle up all of your application files for deployment to a Java environment.}
   gem.add_runtime_dependency 'rake', ['~> 13.0', '>= 13.0.3']
   gem.add_runtime_dependency 'rexml', '~> 3.0'
   gem.add_runtime_dependency 'jruby-jars', ['>= 9.4', '< 10.1']
-  gem.add_runtime_dependency 'jruby-rack', ['>= 1.2.3', '< 1.3']
-  gem.add_runtime_dependency 'rubyzip', '>= 3.0.0'
+  gem.add_runtime_dependency 'jruby-rack', '~> 1.2.6'
+  gem.add_runtime_dependency 'rubyzip', '~> 3.0'
   gem.add_runtime_dependency 'ostruct', '~> 0.6.2'
-  gem.add_development_dependency 'jbundler', '0.9.5'
   gem.add_development_dependency 'rspec', '~> 3.0'
+  gem.add_development_dependency 'drb', ['~> 2.2', '>= 2.2.3']
+  gem.add_development_dependency 'jbundler', '~> 0.9.5'
 end


### PR DESCRIPTION
Dependabot used to be enabled in the v1 days, but fell by the wayside. Get it back to help us manage possible updates needed.

- makes minor tweaks to gemspec to avoid warnings on unconstrained dependency versions
- bump drb to see if it improves stability (sometimes flakes during shutdown on modern JRuby)