### PR TITLE
Create config dir if it is missing

### DIFF
--- a/lib/warbler/config.rb
+++ b/lib/warbler/config.rb
@@ -15,7 +15,8 @@ module Warbler
     include RakeHelper
 
     TOP_DIRS = %w(app db config lib log script vendor)
-    FILE = "config/warble.rb"
+    CONFIG_DIR = "config"
+    FILE = "#{CONFIG_DIR}/warble.rb"
     BUILD_GEMS = %w(warbler rake rcov)
 
     include Traits

--- a/lib/warbler/task.rb
+++ b/lib/warbler/task.rb
@@ -151,12 +151,15 @@ module Warbler
         if File.exist?(Warbler::Config::FILE) && ENV["FORCE"].nil?
           puts "There's another bird sitting on my favorite branch"
           puts "(file '#{Warbler::Config::FILE}' already exists. Pass argument FORCE=1 to override)"
-        elsif !File.directory?("config")
-          puts "I'm confused; my favorite branch is missing"
-          puts "(directory 'config' is missing)"
-        else
-          cp "#{Warbler::WARBLER_HOME}/warble.rb", Warbler::Config::FILE
+          next
         end
+
+        if !File.directory?(Warbler::Config::CONFIG_DIR)
+          puts "config dir is missing, creating it"
+          mkdir_p Warbler::Config::CONFIG_DIR
+        end
+
+        cp "#{Warbler::WARBLER_HOME}/warble.rb", Warbler::Config::FILE
       end
     end
 

--- a/spec/warbler/application_spec.rb
+++ b/spec/warbler/application_spec.rb
@@ -57,12 +57,13 @@ describe Warbler::Application do
     expect(capture { Warbler::Application.new.run }).to match /already exists/
   end
 
-  it "should complain if the config directory is missing" do
+  it "should create the config dir if it is missing" do
     begin
       mv "config", "config-tmp"
       ARGV.unshift "config"
-      expect(capture { Warbler::Application.new.run }).to match /missing/
+      expect(capture { Warbler::Application.new.run }).to match /missing, creating/
     ensure
+      rm_r "config"
       mv "config-tmp", "config"
     end
   end


### PR DESCRIPTION
A user requesting a new configuration should not have to create the config dir; if it does not exist, just create it.