### PR TITLE
fix: Fix spurious NullPointerExceptions during executable war shutdown

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,7 @@
 == Unreleased
 
+- fix: NullPointerException during shutdown with executable war files
+
 == 2.1.0
 
 Requires JRuby >= 9.4 due to needing Ruby 3.0+ compatibility.

--- a/ext/JarMain.java
+++ b/ext/JarMain.java
@@ -222,7 +222,9 @@ public class JarMain implements Runnable {
     public void run() {
         // If the URLClassLoader isn't closed, on Windows, temp JARs won't be cleaned up
         try {
-            invokeMethod(classLoader, "close");
+            if (classLoader != null) {
+                invokeMethod(classLoader, "close");
+            }
         }
         catch (NoSuchMethodException e) { } // We're not being run on Java >= 7
         catch (Exception e) { error(e); }


### PR DESCRIPTION
Executable wars don't set the classloader, because they do not initialize the scripting engine.

Currently you get the below during shutdown

```
ERROR: java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "self" is null
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "self" is null
	at JarMain.invokeMethod(JarMain.java:268)
	at JarMain.invokeMethod(JarMain.java:263)
	at JarMain.run(JarMain.java:225)
	at WarMain.run(WarMain.java:367)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```