### PR TITLE
fix: Log to stderr by default with default bundled Jetty 9.4

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,6 +1,7 @@
 == Unreleased
 
 - fix: NullPointerException during shutdown with executable war files
+- fix: Jetty wars don't have console logging enabled by default
 
 == 2.1.0
 

--- a/lib/warbler/version.rb
+++ b/lib/warbler/version.rb
@@ -6,5 +6,5 @@
 #++
 
 module Warbler
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/lib/warbler/web_server.rb
+++ b/lib/warbler/web_server.rb
@@ -106,7 +106,6 @@ CONFIG
       jar.files["WEB-INF/webserver.properties"] ||= StringIO.new(<<-PROPS)
 mainclass = org.eclipse.jetty.runner.Runner
 args = args0,args1,args2,args3,args4,args5,args6
-props = jetty.home
 args0 = --host
 args1 = {{host}}
 args2 = --port
@@ -114,7 +113,9 @@ args3 = {{port}}
 args4 = --config
 args5 = {{config}}
 args6 = {{warfile}}
+props = jetty.home,org.eclipse.jetty.util.log.class
 jetty.home = {{webroot}}
+org.eclipse.jetty.util.log.class = org.eclipse.jetty.util.log.StdErrLog
 PROPS
     end
   end

--- a/spec/warbler/web_server_spec.rb
+++ b/spec/warbler/web_server_spec.rb
@@ -41,3 +41,30 @@ describe Warbler::WebServer::Artifact do
   end
 
 end
+
+
+describe Warbler::JettyServer do
+
+  it "creates default configuration for jetty" do
+    files = {}
+    jar = double('jar file')
+    allow(jar).to receive(:files).and_return files
+
+    def server = Warbler::JettyServer.new
+
+    server.add(jar)
+    expect(files['WEB-INF/webserver.jar']).to match /org\/eclipse\/jetty\/jetty-runner\/9\.4.*\/jetty-runner-9\.4.*.jar/
+    expect(files['WEB-INF/webserver.xml'].string).to include 'org.eclipse.jetty.server.Server'
+
+    props = files['WEB-INF/webserver.properties']
+              .string
+              .each_line(chomp: true)
+              .to_h { |line| line.split(' = ', 2) }
+
+    expect(props.keys.to_set).to eql Set.new(['mainclass', 'args', 'args0', 'args1', 'args2', 'args3', 'args4', 'args5', 'args6', 'props', 'jetty.home', 'org.eclipse.jetty.util.log.class'])
+
+    expect(props['mainclass']).to eq 'org.eclipse.jetty.runner.Runner'
+    expect(props['props']).to eq 'jetty.home,org.eclipse.jetty.util.log.class'
+    expect(props['org.eclipse.jetty.util.log.class']).to eq 'org.eclipse.jetty.util.log.StdErrLog'
+  end
+end


### PR DESCRIPTION
By default Jetty 9.4 seems to try and log to SLF4J and even there is no SLF4J logging binding configured it seems to just swallow the logs. For now, use the default std err logger which probably is similar to earlier versions.

To fix this a bit more cleanly we'd need to add a slf4j implementation onto the classpath somewhere, but I couldnt get it to work cleanly with the approaches to do so so doing this for now. (various problems with jar-dependencies or bundler etc)

Without

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
WARNING: jetty-runner is deprecated.
         See Jetty Documentation for startup options
         https://jetty.org/docs/
```

With

```
2025-10-26 15:57:46.967:INFO::main: Logging initialized @102ms to org.eclipse.jetty.util.log.StdErrLog
WARNING: jetty-runner is deprecated.
         See Jetty Documentation for startup options
         https://jetty.org/docs/
2025-10-26 15:57:46.970:INFO:oejr.Runner:main: Runner
2025-10-26 15:57:47.028:INFO:oejs.Server:main: jetty-9.4.58.v20250814; built: 2025-08-14T02:28:49.637Z; git: 8f1440587e9e4ae7db3d74cf205643f3d707148d; jvm 21.0.8+9-LTS
2025-10-26 15:57:48.078:INFO:oeja.AnnotationConfiguration:main: Scanning elapsed time=190ms
2025-10-26 15:57:48.182:INFO:oejs.session:main: DefaultSessionIdManager workerName=node0
2025-10-26 15:57:48.182:INFO:oejs.session:main: No SessionScavenger set, using defaults
2025-10-26 15:57:48.183:INFO:oejs.session:main: node0 Scavenging every 660000ms
2025-10-26 15:57:48.218:INFO:oejshC.ROOT:main: jruby 10.0.2.0 (3.4.2) 2025-08-07 cba6031bd0 OpenJDK 64-Bit Server VM 21.0.8+9-LTS on 21.0.8+9-LTS +indy +jit [arm64-darwin]
2025-10-26 15:57:48.219:INFO:oejshC.ROOT:main: using a shared (thread-safe) runtime
2025-10-26 15:57:52.177:INFO:oejsh.ContextHandler:main: Started o.e.j.w.WebAppContext@27808f31{/,file:///private/var/folders/jd/4f37d32x24j00n2s1_tkt0jh0000gn/T/jetty-0_0_0_0-8080-rails7_war-_-any-5272537787575681937/webapp/,AVAILABLE}{file:///Users/chad/Projects/community/jruby-rack/examples/rails7/rails7.war}
2025-10-26 15:57:52.189:INFO:oejs.AbstractConnector:main: Started ServerConnector@2b552920{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2025-10-26 15:57:52.190:INFO:oejs.Server:main: Started @5329ms
2025-10-26 15:58:58.094:INFO:oejs.AbstractConnector:JettyShutdownThread: Stopped ServerConnector@2b552920{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2025-10-26 15:58:58.095:INFO:oejs.session:JettyShutdownThread: node0 Stopped scavenging
2025-10-26 15:58:58.371:INFO:oejsh.ContextHandler:JettyShutdownThread: Stopped o.e.j.w.WebAppContext@27808f31{/,null,STOPPED}{file:///Users/chad/Projects/community/jruby-rack/examples/rail
```