### PR TITLE
chore: relax rubyzip requirement to allow rubyzip 2.x

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -2,6 +2,7 @@
 
 - fix: NullPointerException during shutdown with executable war files
 - fix: Jetty wars don't have console logging enabled by default
+- #592: chore: relax rubyzip requirement to allow rubyzip 2.x
 
 == 2.1.0
 

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -34,7 +34,7 @@ bundle up all of your application files for deployment to a Java environment.}
   gem.add_runtime_dependency 'rexml', '~> 3.0'
   gem.add_runtime_dependency 'jruby-jars', ['>= 9.4', '< 10.1']
   gem.add_runtime_dependency 'jruby-rack', '~> 1.2.6'
-  gem.add_runtime_dependency 'rubyzip', '~> 3.0'
+  gem.add_runtime_dependency 'rubyzip', ['>= 2.1.0', '< 4']
   gem.add_runtime_dependency 'ostruct', '~> 0.6.2'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'drb', ['~> 2.2', '>= 2.2.3']


### PR DESCRIPTION
The only change with our rubyzip 3 upgrade in #571 was to use keyword arg `create: true` rather than positional `create = true`. 

Support for keyword args like this was added in rubyzip 2.1.0 (https://github.com/rubyzip/rubyzip/releases/tag/v2.1.0) via https://github.com/rubyzip/rubyzip/pull/418 so we don't need such a strict requirement on 3.x. The other breaking changes in rubyzip 3.0 don't appear to be important for warbler: https://github.com/rubyzip/rubyzip/wiki/Updating-to-version-3.x

Manually tested this via RubyZip 2.x locally via `bundle exec rake spec integration` with JRuby 9.4 and works fine.