### PR TITLE
chore: relax jruby-rack requirement to allow compatibility with upcoming 1.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - #589: fix: Jetty wars don't have console logging enabled by default
 - #591: chore: clean up obsolete & deprecated code from 2.0.x and old Bundler versions
 - #592: chore: relax rubyzip requirement to allow rubyzip 2.x
+- #593: chore: relax jruby-rack requirement to allow compatibility with upcoming 1.3.x
 
 ## 2.1.0
 

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -33,7 +33,7 @@ bundle up all of your application files for deployment to a Java environment.}
   gem.add_runtime_dependency 'rake', ['~> 13.0', '>= 13.0.3']
   gem.add_runtime_dependency 'rexml', '~> 3.0'
   gem.add_runtime_dependency 'jruby-jars', ['>= 9.4', '< 10.1']
-  gem.add_runtime_dependency 'jruby-rack', '~> 1.2.6'
+  gem.add_runtime_dependency 'jruby-rack', ['>= 1.2.6', '< 1.4']
   gem.add_runtime_dependency 'rubyzip', ['>= 2.1.0', '< 4']
   gem.add_runtime_dependency 'ostruct', '~> 0.6.2'
   gem.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
There are no known changes needed to be made within warbler to be compatible with upcoming jruby-rack 1.3.x (current `master`/`HEAD`). It already doesn't use any of the removed deprecations.

Users themselves who have custom jruby-rack config via `config.webxml` may need to change that config, however that isn't something abstracted by warbler and they can constrain jruby-rack to a lower version if needed.

I've tested warbler locally with jruby-rack 1.3.x:
- with and without Rack 3.x support https://github.com/jruby/jruby-rack/pull/325
- tested all the [jruby-rack examples](https://github.com/jruby/jruby-rack/tree/master/examples) with warbler 2.1.1
- tested warbler with  `bundle exec rake spec`
- tested warbler with `bundle exec rake integration` pointing to 1.3.x jruby-rack jar
  - Rails 7.2 test with Rack 2.2
  - Rails 7.2 test with Rack 3.1

Making this change now should allow folks to upgrade jruby-rack without another warbler release needed since it seems compatible as-is.