### PR TITLE
fix: disable escaping in Jetty logging for executable wars by default

### DIFF
--- a/lib/warbler/web_server.rb
+++ b/lib/warbler/web_server.rb
@@ -113,9 +113,10 @@ args3 = {{port}}
 args4 = --config
 args5 = {{config}}
 args6 = {{warfile}}
-props = jetty.home,org.eclipse.jetty.util.log.class
+props = jetty.home,org.eclipse.jetty.util.log.class,org.eclipse.jetty.util.log.stderr.ESCAPE
 jetty.home = {{webroot}}
 org.eclipse.jetty.util.log.class = org.eclipse.jetty.util.log.StdErrLog
+org.eclipse.jetty.util.log.stderr.ESCAPE = false
 PROPS
     end
   end

--- a/spec/warbler/web_server_spec.rb
+++ b/spec/warbler/web_server_spec.rb
@@ -61,10 +61,14 @@ describe Warbler::JettyServer do
               .each_line(chomp: true)
               .to_h { |line| line.split(' = ', 2) }
 
-    expect(props.keys.to_set).to eql Set.new(['mainclass', 'args', 'args0', 'args1', 'args2', 'args3', 'args4', 'args5', 'args6', 'props', 'jetty.home', 'org.eclipse.jetty.util.log.class'])
+    expect(props.keys.to_set).to eql Set.new(
+      ['mainclass', 'args', 'args0', 'args1', 'args2', 'args3', 'args4', 'args5', 'args6', 'props', 'jetty.home',
+       'org.eclipse.jetty.util.log.class', 'org.eclipse.jetty.util.log.stderr.ESCAPE']
+    )
 
     expect(props['mainclass']).to eq 'org.eclipse.jetty.runner.Runner'
-    expect(props['props']).to eq 'jetty.home,org.eclipse.jetty.util.log.class'
+    expect(props['props']).to eq 'jetty.home,org.eclipse.jetty.util.log.class,org.eclipse.jetty.util.log.stderr.ESCAPE'
     expect(props['org.eclipse.jetty.util.log.class']).to eq 'org.eclipse.jetty.util.log.StdErrLog'
+    expect(props['org.eclipse.jetty.util.log.stderr.ESCAPE']).to eq 'false'
   end
 end


### PR DESCRIPTION
Follow-up to #589 to make the default std err logs more usable

jruby-rack and jruby in general can often log large backtraces and such inside logging messages, which Jetty's default stderrlog will escape in a way that makes them unreadable.

Users who need a "proper" logging solution are better to switch to SLF4J logging anyway, which requires a jar implementation to be added into warbler and some `webserver.properties` configuration. We can address this to work-by-default for a Jetty 10+ upgrade where this older StdErr logging approach is gone (see https://github.com/jetty/jetty.project/issues/4572). 