### PR TITLE
test: ensure Rails activerecord compatibility with JRuby 10.1

### DIFF
--- a/Mavenfile
+++ b/Mavenfile
@@ -44,6 +44,6 @@ plugin :invoker, '3.10.1' do
                  :goals => ['verify'],
                  :projectsDirectory => 'integration',
                  :pomIncludes => [ '*/pom.xml' ],
-                 :pomExcludes => Java::JavaLang::System.getProperty('jruby.version').start_with?('10.1') ? ['rails7_test/pom.xml'] : [],
+                 :pomExcludes => [],
                  :streamLogs => true )
 end


### PR DESCRIPTION

  - [x] needs one of these to fix the tests
      - arjdbc 72.3 https://github.com/jruby/activerecord-jdbc-adapter/pull/1210 
      - jruby 10.1.1 https://github.com/jruby/jruby/pull/9456 
      - https://github.com/jruby/jruby/issues/9458 to make the error easier to see/handle without weird monkey-patch

