### PR TITLE
chore: deprecate JBundler support for eventual removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - #592: chore: relax rubyzip requirement to allow rubyzip 2.x
 - #593: chore: relax jruby-rack requirement to allow compatibility with upcoming 1.3.x
 - #624: chore: remove use of deprecated JRuby methods removed in JRuby 10.1
+- #634: chore: deprecate JBundler trait for removal
 
 ## 2.1.0
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -139,10 +139,14 @@ Warbler supports Bundler for gems and git repositories, but not for plain path
 components. Warbler will warn when a +:path+ component is found in the +Gemfile+
 and will refuse to include it in the archive.
 
-=== JBundler (experimental)
+=== JBundler (deprecated, experimental)
 
-Applications that use JBundler[http://github.com/mkristian/jbundler], detected
-via presence of a +Jarfile+, will have the jars packaged up into the archive. the JBundler gem is **not** needed for runtime since all jars are already part of the classloader.
+Applications that use JBundler[http://github.com/jruby/jbundler], detected via presence of a +Jarfile+, will have
+the jars packaged up into the archive. The JBundler gem is **not** needed for runtime since all jars are already part of the classloader.
+
+JBundler is EOL; and this capability is thus deprecated for removal in a future release, and is not recommended for use.
+The recommended replacement is bundler with +jar-dependencies+ (bundled with modern JRuby); but requires some work for
+compatibility. See https://github.com/jruby/warbler/issues/481 for more details and contribute if you'd like this feature to be retained and supported.
 
 == War Files
 

--- a/lib/warbler/jar.rb
+++ b/lib/warbler/jar.rb
@@ -334,6 +334,6 @@ module Warbler
 
     # Java-boosted jar creation for JRuby; replaces #create_jar and
     # #entry_in_jar with Java version
-    require 'warbler_jar' if defined?(JRUBY_VERSION) && JRUBY_VERSION >= "1.5"
+    require 'warbler_jar' if defined?(JRUBY_VERSION)
   end
 end

--- a/lib/warbler/traits/jbundler.rb
+++ b/lib/warbler/traits/jbundler.rb
@@ -23,6 +23,7 @@ module Warbler
 
       def before_configure
         config.jbundler = true
+        warn "JBundler support is deprecated due to the EOL of JBundler. See https://github.com/jruby/warbler/issues/481 for discussion on replacement with jar-dependencies."
       end
 
       def after_configure
@@ -35,7 +36,7 @@ module Warbler
         if File.exist?( classpath )
           require File.expand_path( classpath )
         else
-          raise 'jbundler support needs jruby to create a local config: jruby -S jbundle install'
+          raise 'JBundler support needs JRuby to create a local config: jruby -S jbundle install'
         end
         # use only the jars from jbundler and jruby
         config.java_libs += jruby_jars

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,27 +123,17 @@ module ExampleGroupHelpers
       end
     end
 
-    if defined?(JRUBY_VERSION)
-      require 'jruby'
-      let(:drb) do
-        drb_thread = Thread.new do
-          ruby '--dev', "-I#{Warbler::WARBLER_HOME}/lib", File.join(@orig_dir, 'spec/drb_helper.rb')
-        end
-        drb_thread.run
-        drb_thread
+    let(:drb) do
+      drb_thread = Thread.new do
+        ruby '--dev', "-I#{Warbler::WARBLER_HOME}/lib", File.join(@orig_dir, 'spec/drb_helper.rb')
       end
-      after :each do
-        drbclient.stop
-        drb.join
-      end
-    else
-      require 'childprocess'
-      let(:drb) do
-        ChildProcess.build(FileUtils::RUBY, "-I#{Warbler::WARBLER_HOME}/lib", File.join(@orig_dir, 'spec/drb_helper.rb')).tap {|d| d.start }
-      end
-      after :each do
-        drb.stop
-      end
+      drb_thread.run
+      drb_thread
+    end
+
+    after :each do
+      drbclient.stop
+      drb.join
     end
 
     after :all do
@@ -223,6 +213,6 @@ RSpec.configure do |config|
 
   config.after :each do
     Object.remove_const("Rails") if defined?(Rails)
-    rm_rf "vendor"
+    silence { rm_rf "vendor" }
   end
 end

--- a/spec/warbler/jbundler_spec.rb
+++ b/spec/warbler/jbundler_spec.rb
@@ -40,6 +40,10 @@ describe Warbler::Jar, "with JBundler" do
       expect(config.traits).to include(Warbler::Traits::JBundler)
     end
 
+    it "logs deprecation" do
+      expect(capture { Warbler::Traits::JBundler.new(config).before_configure }).to match /JBundler support is deprecated/
+    end
+
     it "detects a Jarfile and process only its jars" do
       use_config do |config|
         config.java_libs << "local.jar"

--- a/spec/warbler/jbundler_spec.rb
+++ b/spec/warbler/jbundler_spec.rb
@@ -76,14 +76,12 @@ describe Warbler::Jar, "with JBundler" do
     run_in_directory "spec/sample_jbundler"
 
     it "does not include the jbundler gem (as it is in the development group)" do
-      pending( "needs JRuby to work" ) unless defined? JRUBY_VERSION
       apply_silently
       expect(config.gems.detect{|k,v| k.name == 'jbundler'}).to be nil
       expect(file_list(/jbundler-/)).to be_empty
     end
 
     it "does not include the jbundler runtime config" do
-      pending( "needs JRuby to work" ) unless defined? JRUBY_VERSION
       apply_silently
       expect(file_list(%r{WEB-INF/.jbundler})).to be_empty
     end

--- a/spec/warbler/task_spec.rb
+++ b/spec/warbler/task_spec.rb
@@ -166,7 +166,7 @@ describe Warbler::Task do
         Warbler::ZipSupport.open("#{config.jar_name}.war") do |zf|
           expect(zf.find_entry("WEB-INF/lib/tasks/utils.rake")).to_not be nil
           expect(zf.find_entry("WEB-INF/lib/rakelib/")).to_not be nil
-          expect(zf.find_entry("WEB-INF/lib/rakelib/utils.rake")).to_not be nil if defined?(JRUBY_VERSION)
+          expect(zf.find_entry("WEB-INF/lib/rakelib/utils.rake")).to_not be nil
         end
       end
 

--- a/warble.rb
+++ b/warble.rb
@@ -10,7 +10,7 @@
 # - `Warbler::Traits::Bundler`   - package with the gems implied by a bundle Gemfile/Gemfile.lock
 # - `Warbler::Traits::Gemspec`   - package with the gems implied by a gemspec
 # - `Warbler::Traits::NoGemspec` - package only with the gems implied by that in a local `lib` folder
-# - `Warbler::Traits::JBundler`  - (experimental) package with the jars implied by a `Jarfile`
+# - `Warbler::Traits::JBundler`  - (deprecated, experimental) package with the jars implied by a `Jarfile`
 # - `Warbler::Traits::Rails`     - package with the necessary startup logic to boot a Rails application
 # - `Warbler::Traits::Rack`      - package with the necessary startup logic to boot a standalone Rack (non-Rails) application
 # forced_traits = [Warbler::Traits::Jar]


### PR DESCRIPTION
As discussed at https://github.com/jruby/warbler/issues/481 JBundler is essentially EOL. We should warn any users of this.