### PR TITLE
fix: ensure JRuby 10.1 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: gem uninstall -a jruby-launcher
 
       - name: Install dependencies
-        run: bundle install
+        run: BUNDLE_JOBS=1 bundle install
 
       - name: Run tests
         run: bundle exec rake ${{ matrix.task }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 21, 25]
-        ruby-version: [jruby-9.4, jruby-10.0]
+        ruby-version: [jruby-9.4, jruby-10.0, jruby-10.1]
         task: ['', integration]
         exclude:
-          # JRuby 10 requires Java 21 minimum
-          - ruby-version: jruby-10.0
+          - ruby-version: jruby-10.0  # JRuby 10 requires Java 21 minimum
+            java-version: 8
+          - ruby-version: jruby-10.1  # JRuby 10 requires Java 21 minimum
             java-version: 8
 
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.1 (UNRELEASED)
 
+- #623: fix: ensure compatibility with JRuby 10.1
 - #583: fix: Create config dir if it's missing for simpler usage
 - #588: fix: NullPointerException during shutdown with executable war files
 - #589: fix: Jetty wars don't have console logging enabled by default

--- a/Mavenfile
+++ b/Mavenfile
@@ -1,4 +1,5 @@
 #-*- mode: ruby -*-
+warn "ruby-maven is running fixed JRuby version #{JRUBY_VERSION}"
 
 # tell the gem setup for maven where the java sources are
 # and how to name the jar file (default path for the jar: ./lib )
@@ -53,5 +54,7 @@ plugin :invoker, '3.9.1' do
                  },
                  :goals => ['verify'],
                  :projectsDirectory => 'integration',
+                 :pomIncludes => [ '*/pom.xml' ],
+                 :pomExcludes => Java::JavaLang::System.getProperty('jruby.version').start_with?('10.1') ? ['rails7_test/pom.xml'] : [],
                  :streamLogs => true )
 end

--- a/Rakefile
+++ b/Rakefile
@@ -29,8 +29,6 @@ mvn << "-Dbundler.version=#{Bundler::VERSION}"
 mvn << '--no-transfer-progress'
 mvn << '--color=always'
 
-mvn.inherit_jruby_version
-
 desc 'compile java sources and build jar'
 task :jar do
   success = mvn.prepare_package

--- a/spec/warbler/jbundler_spec.rb
+++ b/spec/warbler/jbundler_spec.rb
@@ -7,7 +7,8 @@
 
 require File.expand_path('../../spec_helper', __FILE__)
 
-describe Warbler::Jar, "with JBundler" do
+should_skip = "JBundler is deprecated and not supported on Ruby 4.0 / JRuby 10.1" if RUBY_VERSION.to_f >= 4.0 || false
+describe Warbler::Jar, "with JBundler", skip: should_skip do
   use_fresh_rake_application
   use_fresh_environment
   run_out_of_process_with_drb

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -32,7 +32,7 @@ bundle up all of your application files for deployment to a Java environment.}
 
   gem.add_runtime_dependency 'rake', ['~> 13.0', '>= 13.0.3']
   gem.add_runtime_dependency 'rexml', '~> 3.0'
-  gem.add_runtime_dependency 'jruby-jars', ['>= 9.4', '< 10.1']
+  gem.add_runtime_dependency 'jruby-jars', ['>= 9.4', '< 10.2']
   gem.add_runtime_dependency 'jruby-rack', ['>= 1.2.7', '< 1.4']
   gem.add_runtime_dependency 'rubyzip', ['>= 2.1.0', '< 4']
   gem.add_runtime_dependency 'ostruct', '~> 0.6.2'


### PR DESCRIPTION
Runs tests against JRuby 10.1, except
- permanently excludes running JBundler tests. JBundler likely won't be supported for JRuby 10.1
- temporarily does not run Rails 7.2 test due to issue discussed at https://github.com/jruby/warbler/pull/623
 
Tests/build subject to https://github.com/ruby/rubygems/issues/9386 now, which it wasn't before, for some reason, so keeping `BUNDLE_JOBS=1` for now.