### PR TITLE
build: refactor build to prefer raw gem installs for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        task: ['', integration]
+        task: [spec, integration]
         ruby-version: [jruby-9.4, jruby-10.0, jruby-10.1]
         java-version: [8, 17, 21, 25]
         jruby-rack-version: ['1.2', '1.3', '2.0']
@@ -33,9 +33,9 @@ jobs:
           - task: 'integration'       # War integration tests require Java 17
             java-version: 8
           - jruby-rack-version: '1.3' # No need to vary jruby-rack version for non-integration
-            task: ''
+            task: spec
           - jruby-rack-version: '2.0' # No need to vary jruby-rack version for non-integration
-            task: ''
+            task: spec
           - jruby-rack-version: '1.3' # JRuby-Rack 1.3+ requires JRuby 10
             ruby-version: jruby-9.4
           - jruby-rack-version: '2.0' # JRuby-Rack 1.3+ requires JRuby 10
@@ -44,8 +44,9 @@ jobs:
       fail-fast: false
 
     env:
-      # speed up all those subprocesses
-      JRUBY_OPTS: --dev
+      JRUBY_OPTS: --dev               # speed up all those subprocesses
+      BUNDLE_JOBS: "1"                # serial installs: parallel installs race the jar-dependencies post-install hook needed by psych: see https://github.com/ruby/rubygems/issues/9386
+      BUNDLE_GLOBAL_GEM_CACHE: "true" # keep downloaded .gem archives in ~/.bundle/cache so they can be cached across runs
 
     steps:
       - name: checkout
@@ -56,18 +57,35 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
-          cache: maven
 
       - name: Set up ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-      - name: Remove jruby-launcher # not sure where this is coming from but causes some specs to fail
-        run: gem uninstall -a jruby-launcher
+      - name: Set up dependency cache
+        uses: actions/cache@v6
+        with:
+          # ~/.m2/repository: maven artifacts - vary by jruby version (jruby-complete),
+          #   jruby-rack series (jetty ee8 vs ee11) and task (integration resolves more).
+          # ~/.bundle/cache: bundler's global gem cache (BUNDLE_GLOBAL_GEM_CACHE above)
+          #   of downloaded .gem archives - avoids re-downloads while gems still install
+          #   into the system gem home the specs require.
+          path: |
+            ~/.m2/repository
+            ~/.bundle/cache
+          key: deps-${{ runner.os }}-${{ matrix.ruby-version }}-rack${{ matrix.jruby-rack-version }}-${{ matrix.task }}-${{ hashFiles('warbler.gemspec', 'Gemfile', 'Mavenfile', 'integration/pom.xml', 'integration/*/src/main/ruby/Gemfile') }}
+          restore-keys: |
+            deps-${{ runner.os }}-${{ matrix.ruby-version }}-rack${{ matrix.jruby-rack-version }}-${{ matrix.task }}-
+            deps-${{ runner.os }}-${{ matrix.ruby-version }}-rack${{ matrix.jruby-rack-version }}-
+            deps-${{ runner.os }}-${{ matrix.ruby-version }}-
+            deps-${{ runner.os }}-
 
       - name: Install dependencies
-        run: BUNDLE_JOBS=1 bundle install
+        run: bundle install # Manage our own cache, as some specs need a clean bundler environment which setup-ruby would dirty
+
+      - name: Remove jruby-launcher # not sure where this is coming from but causes some specs to fail
+        run: gem uninstall -a jruby-launcher
 
       - name: Run tests
         run: bundle exec rake ${{ matrix.task }} "JRUBY_RACK_VERSION=${{ matrix.jruby-rack-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,4 @@ jobs:
         run: BUNDLE_JOBS=1 bundle install
 
       - name: Run tests
-        run: bundle exec rake ${{ matrix.task }} "JRUBY_RACK_VERSION='[${{ matrix.jruby-rack-version }},${{ matrix.jruby-rack-version }}.99999)'"
+        run: bundle exec rake ${{ matrix.task }} "JRUBY_RACK_VERSION=${{ matrix.jruby-rack-version }}"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,12 @@ gemspec
 
 group :development, :test do
   gem 'rdoc', '~> 7.0', :require => nil
+  gem 'rspec', '~> 3.0'
+  gem 'drb', '~> 2.2', '>= 2.2.3'
+  gem 'ruby-maven', '~> 3.9'
+
+  # JBundler is unsupported on JRuby 10.1
+  gem 'jbundler', '~> 0.9.5' if RUBY_VERSION.to_f < 4.0
 
   if defined?(JRUBY_VERSION)
     # force jruby-jars to use current JRuby version for testing

--- a/Mavenfile
+++ b/Mavenfile
@@ -1,16 +1,16 @@
 #-*- mode: ruby -*-
 warn "ruby-maven is running fixed JRuby version #{JRUBY_VERSION}"
 
-# tell the gem setup for maven where the java sources are
-# and how to name the jar file (default path for the jar: ./lib )
-gemspec( :jar => 'warbler_jar.jar',
-         :source => 'ext' )
+require File.expand_path('lib/warbler/version', File.dirname(__FILE__))
+
+id "org.jruby.warbler:warbler-jar:#{Warbler::VERSION}"
+packaging 'jar'
 
 properties(
   'project.build.sourceEncoding' => 'UTF-8',
-  'mavengem.wagon.version' => '2.0.3',
+  'maven.compiler.release' => '8',
   'jruby.plugins.version' => '3.0.6',
-  'jruby-rack.version' => '[1.2,1.2.99999)',
+  'jruby-rack.version' => '1.2',
 )
 
 # dependencies needed for compilation
@@ -18,26 +18,28 @@ scope :provided do
   jar 'org.jruby:jruby', '${jruby.version}'
 end
 
-plugin :clean, '3.5.0'
-plugin :compiler, '3.15.0', :release => '8'
+build do
+  source_directory 'ext'
+  final_name 'warbler_jar'
+end
+
+plugin :clean, '3.5.0', :filesets => [ { :directory => 'lib', :includes => [ 'warbler_jar.jar' ] } ]
+plugin :compiler, '3.15.0'
 plugin :resources, '3.5.0'
-plugin :jar, '3.5.0' do
-  execute_goals(:phase => 'none') # Avoid a duplicate execution with that defined by the :gemspec directive
+plugin :jar, '3.5.0', :outputDirectory => 'lib' do
+  # build the jar before the (rake-driven) gem packaging rather than at package
+  execute_goals :jar, :id => 'default-jar', :phase => 'prepare-package'
 end
 plugin :install, '3.1.4'
 
-gem 'bundler', '${bundler.version}'
-gem 'jruby-jars', '${jruby.version}'
-gem 'jruby-rack', '${jruby-rack.version}'
-
 plugin :invoker, '3.10.1' do
-  execute_goals( :install, :run,
+  execute_goals( :run,
                  :id => 'integration-test',
                  :properties => {
+                   'maven.compiler.release' => '${maven.compiler.release}',
                    'jruby.plugins.version' => '${jruby.plugins.version}',
-                   'warbler.version' => '${project.version}',
+                   'warbler.version' => Warbler::VERSION,
                    'jruby.version' => '${jruby.version}',
-                   'bundler.version' => '${bundler.version}',
                    'jruby-rack.version' => '${jruby-rack.version}',
                    'style.color' => 'always',
                  },

--- a/Rakefile
+++ b/Rakefile
@@ -10,11 +10,11 @@ require 'bundler/gem_helper'
 Bundler::GemHelper.install_tasks :dir => File.dirname(__FILE__)
 
 require 'rake/clean'
-CLEAN << "pkg" << "doc" << Dir['integration/**/target'] << "lib/warbler_jar.jar"
+CLEAN << "pkg" << "doc" << "target" << Dir['integration/**/target'] << "lib/warbler_jar.jar"
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = ['--color', "--format documentation"]
+  t.rspec_opts = ['--force-color', "--format documentation"]
 end
 
 task :spec => :jar
@@ -26,7 +26,6 @@ require 'maven/ruby/maven'
 mvn = Maven::Ruby::Maven.new
 mvn << "-Djruby.version=#{JRUBY_VERSION}"
 mvn << "-Djruby-rack.version=#{ENV['JRUBY_RACK_VERSION']}" if ENV['JRUBY_RACK_VERSION']
-mvn << "-Dbundler.version=#{Bundler::VERSION}"
 mvn << '--no-transfer-progress'
 mvn << '--color=always'
 
@@ -37,7 +36,7 @@ task :jar do
 end
 
 desc 'run some integration test'
-task :integration => :jar do
+task :integration => :build do
   success = mvn.verify
   exit(1) unless success
 end

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -221,6 +221,7 @@
                 <env>
                   <BUNDLE_VERSION>system</BUNDLE_VERSION>
                   <BUNDLE_DISABLE_SHARED_GEMS>true</BUNDLE_DISABLE_SHARED_GEMS>
+                  <BUNDLE_GLOBAL_GEM_CACHE>true</BUNDLE_GLOBAL_GEM_CACHE>
                 </env>
                 <args>-C ${basedir}/src/main/ruby -S bundle install</args>
               </configuration>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -10,14 +10,18 @@
   <properties>
     <jruby.plugins.version>3.0.6</jruby.plugins.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <gem.home>${basedir}/../../pkg/rubygems</gem.home>
-    <gem.path>${basedir}/../../pkg/rubygems</gem.path>
+    <maven.compiler.release>8</maven.compiler.release>
 
     <!-- Default versions, overridden from parent when running tests acros env -->
     <warbler.version>2.1.3.pre</warbler.version>
     <jruby.version>9.4.15.0</jruby.version>
-    <bundler.version>2.6.3</bundler.version>
-    <jruby-rack.version>[1.2,1.2.99999)</jruby-rack.version>
+    <!-- jruby-rack series to test against: 1.2, 1.3 or 2.0 (expanded to a `~> x.y.0` gem requirement) -->
+    <jruby-rack.version>1.2</jruby-rack.version>
+    <warbler.gem>${basedir}/../../pkg/warbler-${warbler.version}.gem</warbler.gem>
+
+    <!-- Test locations -->
+    <gem.home>${basedir}/../../pkg/rubygems-jruby-${jruby.version}-rack-${jruby-rack.version}</gem.home>
+    <gem.path>${basedir}/../../pkg/rubygems-jruby-${jruby.version}-rack-${jruby-rack.version}</gem.path>
   </properties>
 
   <profiles>
@@ -35,7 +39,7 @@
     <profile>
       <id>ee11</id>
       <activation>
-        <property><name>jruby-rack.version</name><value>[2.0,2.0.99999)</value></property>
+        <property><name>jruby-rack.version</name><value>2.0</value></property>
       </activation>
       <properties>
         <jetty-maven-plugin.group>org.eclipse.jetty.ee11</jetty-maven-plugin.group>
@@ -45,60 +49,16 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>rubygems</id>
-      <url>mavengem:https://rubygems.org</url>
-    </repository>
-  </repositories>
-
   <dependencies>
-    <dependency>
-      <groupId>rubygems</groupId>
-      <artifactId>warbler</artifactId>
-      <version>${warbler.version}</version>
-      <type>gem</type>
-    </dependency>
-    <dependency>
-      <groupId>rubygems</groupId>
-      <artifactId>bundler</artifactId>
-      <version>${bundler.version}</version>
-      <type>gem</type>
-    </dependency>
-    <dependency>
-      <groupId>rubygems</groupId>
-      <artifactId>jruby-jars</artifactId>
-      <version>${jruby.version}</version>
-      <type>gem</type>
-    </dependency>
-    <dependency>
-      <groupId>rubygems</groupId>
-      <artifactId>jruby-rack</artifactId>
-      <version>${jruby-rack.version}</version>
-      <type>gem</type>
-    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.14.4</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>3.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>org.jruby.maven</groupId>
-        <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.3</version>
-      </extension>
-    </extensions>
     <defaultGoal>verify</defaultGoal>
     <resources>
       <resource>
@@ -135,11 +95,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.15.0</version>
-        <configuration>
-          <release>8</release>
-        </configuration>
       </plugin>
       <plugin>
+        <!-- these modules use jar packaging only for the java IT lifecycle; suppress the
+             meaningless default jar so only warble's artifact appears in target/ -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.5.1</version>
@@ -163,16 +122,6 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.jruby.maven</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
-        <executions>
-          <execution>
-            <goals><goal>initialize</goal></goals>
           </execution>
         </executions>
       </plugin>
@@ -250,10 +199,30 @@
           </configuration>
           <executions>
             <execution>
+              <id>install-tool-gems</id>
+              <phase>initialize</phase>
+              <goals><goal>jruby</goal></goals>
+              <configuration>
+                <args>-S gem install --no-document --conservative jruby-jars:${jruby.version} jruby-rack:~&gt;${jruby-rack.version}.0</args>
+              </configuration>
+            </execution>
+            <execution>
+              <id>install-warbler</id>
+              <phase>initialize</phase>
+              <goals><goal>jruby</goal></goals>
+              <configuration>
+                <args>-S gem install --no-document ${warbler.gem}</args>
+              </configuration>
+            </execution>
+            <execution>
               <id>bundle-install</id>
               <goals><goal>jruby</goal></goals>
               <configuration>
-                <args>-C ${basedir}/src/main/ruby -S ${gem.home}/bin/bundle install</args>
+                <env>
+                  <BUNDLE_VERSION>system</BUNDLE_VERSION>
+                  <BUNDLE_DISABLE_SHARED_GEMS>true</BUNDLE_DISABLE_SHARED_GEMS>
+                </env>
+                <args>-C ${basedir}/src/main/ruby -S bundle install</args>
               </configuration>
             </execution>
             <execution>

--- a/integration/rails7_test/src/test/java/org/jruby/warbler/Rails7AppTestIT.java
+++ b/integration/rails7_test/src/test/java/org/jruby/warbler/Rails7AppTestIT.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.net.*;
 import java.io.*;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test for simple App.
@@ -18,8 +17,8 @@ public class Rails7AppTestIT {
     @Test
     public void testApp() throws Exception {
         String content = contentFrom("http://localhost:8080/posts/");
-        assertThat(content, containsString("Rails7App"));
-        assertThat(content, containsString("Listing posts"));
+        assertTrue(content.contains("Rails7App"), () -> "expected response to contain 'Rails7App' but was: " + content);
+        assertTrue(content.contains("Listing posts"), () -> "expected response to contain 'Listing posts' but was: " + content);
     }
 
     private static String contentFrom(String url) throws IOException {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,7 +61,9 @@ module ExampleGroupHelpers
   def use_fresh_environment
     before(:each) do
       @env_save = {}
-      (ENV.keys.grep(/BUNDLE/) + ["RUBYOPT"]).each {|k| @env_save[k] = ENV[k]; ENV.delete(k)}
+      # BUNDLE_GLOBAL_GEM_CACHE is kept: it only relocates bundler's download cache
+      # (useful for CI caching) and does not affect the bundler behaviour under test
+      (ENV.keys.grep(/BUNDLE/) - ["BUNDLE_GLOBAL_GEM_CACHE"] + ["RUBYOPT"]).each {|k| @env_save[k] = ENV[k]; ENV.delete(k)}
     end
 
     after(:each) do

--- a/warbler.gemspec
+++ b/warbler.gemspec
@@ -36,12 +36,4 @@ bundle up all of your application files for deployment to a Java environment.}
   gem.add_runtime_dependency 'jruby-rack', ['>= 1.2.7', '< 2.1']
   gem.add_runtime_dependency 'rubyzip', ['>= 2.1.0', '< 4']
   gem.add_runtime_dependency 'ostruct', '~> 0.6.2'
-
-  gem.add_development_dependency 'rspec', '~> 3.0'
-  gem.add_development_dependency 'drb', ['~> 2.2', '>= 2.2.3']
-  gem.add_development_dependency 'ruby-maven', '~> 3.9'
-  gem.add_development_dependency 'bigdecimal' # Needed workaround for maven-tools > vertus > axiom-types lack of explicit bigdecimal dependency for JRuby 10
-
-  # JBundler is unsupported on JRuby 10.1
-  gem.add_development_dependency 'jbundler', '~> 0.9.5' if RUBY_VERSION.to_f < 4.0
 end


### PR DESCRIPTION
As noted in #652, using gem-maven-plugin has all sorts of problems with the matrix build, since it does not resolve `required_ruby_version` correctly (breaking bundler, jruby-rack etc). Since we already build the gem directly via bundler/rake, better to not do things this way, and just use raw gem installs, which avoids the maven integration flow having to deal with jruby-maven-plugins as much.